### PR TITLE
Flowables.mergeInterleaved operator

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -215,7 +215,7 @@
             <plugin>
                 <groupId>org.jacoco</groupId>
                 <artifactId>jacoco-maven-plugin</artifactId>
-                <version>0.7.5.201505241946</version>
+                <version>0.8.1</version>
                 <executions>
                     <execution>
                         <goals>

--- a/src/main/java/com/github/davidmoten/rx2/Flowables.java
+++ b/src/main/java/com/github/davidmoten/rx2/Flowables.java
@@ -1,21 +1,23 @@
 package com.github.davidmoten.rx2;
 
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+
+import org.reactivestreams.Subscription;
+
 import com.github.davidmoten.guavamini.Optional;
 import com.github.davidmoten.rx2.flowable.CachedFlowable;
 import com.github.davidmoten.rx2.flowable.CloseableFlowableWithReset;
-import com.github.davidmoten.rx2.internal.flowable.*;
+import com.github.davidmoten.rx2.internal.flowable.FlowableFetchPagesByRequest;
+import com.github.davidmoten.rx2.internal.flowable.FlowableMatch;
+import com.github.davidmoten.rx2.internal.flowable.FlowableMergeInterleave;
+import com.github.davidmoten.rx2.internal.flowable.FlowableRepeat;
 
 import io.reactivex.Flowable;
 import io.reactivex.Scheduler;
 import io.reactivex.functions.BiFunction;
 import io.reactivex.functions.Consumer;
 import io.reactivex.functions.Function;
-import rx.internal.util.RxRingBuffer;
-
-import org.reactivestreams.Subscription;
-
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicReference;
 
 public final class Flowables {
 
@@ -320,6 +322,8 @@ public final class Flowables {
         }
     }
 
+    private static final int DEFAULT_RING_BUFFER_SIZE = 128;
+
     public static <T> Flowable<T> mergeInterleaved(Flowable<Flowable<T>> flowables,
             int maxConcurrency, int batchSize, boolean delayErrors) {
         return new FlowableMergeInterleave<T>(flowables, maxConcurrency, batchSize, delayErrors);
@@ -327,7 +331,7 @@ public final class Flowables {
 
     public static <T> Flowable<T> mergeInterleaved(Flowable<Flowable<T>> flowables,
             int maxConcurrency) {
-        return new FlowableMergeInterleave<T>(flowables, maxConcurrency, RxRingBuffer.SIZE, true);
+        return new FlowableMergeInterleave<T>(flowables, maxConcurrency, 128, true);
     }
 
     public static <T> MergeInterleaveBuilder<T> mergeInterleaved(Flowable<Flowable<T>> flowables) {
@@ -338,7 +342,7 @@ public final class Flowables {
 
         private Flowable<Flowable<T>> flowables;
         private int maxConcurrency = 4;
-        private int batchSize = RxRingBuffer.SIZE;
+        private int batchSize = DEFAULT_RING_BUFFER_SIZE;
         private boolean delayErrors = false;
 
         MergeInterleaveBuilder(Flowable<Flowable<T>> flowables) {

--- a/src/main/java/com/github/davidmoten/rx2/Flowables.java
+++ b/src/main/java/com/github/davidmoten/rx2/Flowables.java
@@ -10,6 +10,8 @@ import io.reactivex.Scheduler;
 import io.reactivex.functions.BiFunction;
 import io.reactivex.functions.Consumer;
 import io.reactivex.functions.Function;
+import rx.internal.util.RxRingBuffer;
+
 import org.reactivestreams.Subscription;
 
 import java.util.concurrent.TimeUnit;
@@ -314,7 +316,12 @@ public final class Flowables {
         }
     }
 
-    public static <T> Flowable<T> mergeInterleaved(Flowable<Flowable<T>> flowables, int maxConcurrency, int batchSize) {
-        return new FlowableMergeInterleave<T>(flowables, maxConcurrency, batchSize);
+    public static <T> Flowable<T> mergeInterleaved(Flowable<Flowable<T>> flowables, int maxConcurrency, int batchSize,
+            boolean delayError) {
+        return new FlowableMergeInterleave<T>(flowables, maxConcurrency, batchSize, delayError);
+    }
+
+    public static <T> Flowable<T> mergeInterleaved(Flowable<Flowable<T>> flowables, int maxConcurrency) {
+        return new FlowableMergeInterleave<T>(flowables, maxConcurrency, RxRingBuffer.SIZE, true);
     }
 }

--- a/src/main/java/com/github/davidmoten/rx2/Flowables.java
+++ b/src/main/java/com/github/davidmoten/rx2/Flowables.java
@@ -42,32 +42,62 @@ public final class Flowables {
     }
 
     /**
-     * <p>Creates a Flowable that is aimed at supporting calls to a service that provides data in pages where the page sizes are determined by requests from downstream (requests are a part of the backpressure machinery of RxJava).
+     * <p>
+     * Creates a Flowable that is aimed at supporting calls to a service that
+     * provides data in pages where the page sizes are determined by requests from
+     * downstream (requests are a part of the backpressure machinery of RxJava).
      * 
-     * <p><img src="https://raw.githubusercontent.com/davidmoten/rxjava2-extras/master/src/docs/fetchPagesByRequest.png" alt="image">
+     * <p>
+     * <img src=
+     * "https://raw.githubusercontent.com/davidmoten/rxjava2-extras/master/src/docs/fetchPagesByRequest.png"
+     * alt="image">
      * 
-     * <p>Here's an example.
+     * <p>
+     * Here's an example.
      * 
-     * <p>Suppose you have a stateless web service, say a rest service that returns JSON/XML and supplies you with
+     * <p>
+     * Suppose you have a stateless web service, say a rest service that returns
+     * JSON/XML and supplies you with
      * 
-     * <ul><li>the most popular movies of the last 24 hours sorted by descending popularity</li></ul>
-     * 
-     * <p>The service supports paging in that you can pass it a start number and a page size and it will return just that slice from the list.
-     * 
-     * <p>Now I want to give a library with a Flowable definition of this service to my colleagues that they can call in their applications whatever they may be. For example,
-     * 
-     * <ul><li>Fred may just want to know the most popular movie each day,</li>
-     * <li>Greta wants to get the top 20 and then have the ability to keep scrolling down the list in her UI.</li>
+     * <ul>
+     * <li>the most popular movies of the last 24 hours sorted by descending
+     * popularity</li>
      * </ul>
      * 
-     * <p>Let's see how we can efficiently support those use cases. I'm going to assume that the movie data returned by the service are mapped conveniently to objects by whatever framework I'm using (JAXB, Jersey, etc.). The fetch method looks like this:
-     * <pre>{@code
+     * <p>
+     * The service supports paging in that you can pass it a start number and a page
+     * size and it will return just that slice from the list.
+     * 
+     * <p>
+     * Now I want to give a library with a Flowable definition of this service to my
+     * colleagues that they can call in their applications whatever they may be. For
+     * example,
+     * 
+     * <ul>
+     * <li>Fred may just want to know the most popular movie each day,</li>
+     * <li>Greta wants to get the top 20 and then have the ability to keep scrolling
+     * down the list in her UI.</li>
+     * </ul>
+     * 
+     * <p>
+     * Let's see how we can efficiently support those use cases. I'm going to assume
+     * that the movie data returned by the service are mapped conveniently to
+     * objects by whatever framework I'm using (JAXB, Jersey, etc.). The fetch
+     * method looks like this:
+     * 
+     * <pre>
+     * {@code
      * // note that start is 0-based
      * List<Movie> mostPopularMovies(int start, int size);
-     * }</pre>
+     * }
+     * </pre>
      * 
-     * <p>Now I'm going to wrap this synchronous call as a Flowable to give to my colleagues:
-     * <pre>{@code
+     * <p>
+     * Now I'm going to wrap this synchronous call as a Flowable to give to my
+     * colleagues:
+     * 
+     * <pre>
+     * {@code
      * Flowable<Movie> mostPopularMovies(int start) {
      *     return Flowables.fetchPagesByRequest(
      *           (position, n) -> Flowable.fromIterable(mostPopular(position, n)),
@@ -80,56 +110,76 @@ public final class Flowables {
      * Flowable<Movie> mostPopularMovies() {
      *     return mostPopularMovies(0);
      * }
-     * }</pre>
-     * <p>Note particularly that the method above uses a variant of rebatchRequests to limit both minimum and maximum requests. We particularly don't want to allow a single call requesting the top 100,000 popular movies because of the memory and network pressures that arise from that call.
+     * }
+     * </pre>
+     * <p>
+     * Note particularly that the method above uses a variant of rebatchRequests to
+     * limit both minimum and maximum requests. We particularly don't want to allow
+     * a single call requesting the top 100,000 popular movies because of the memory
+     * and network pressures that arise from that call.
      * 
-     * <p>Righto, Fred now uses the new API like this:
-     * <pre>{@code
-     * Movie top = mostPopularMovies()
-     *     .compose(Transformers.maxRequest(1))
-     *     .first()
-     *     .blockingFirst();
-     * }</pre>
-     * <p>The use of maxRequest above may seem unnecessary but strangely enough the first operator requests Long.MAX_VALUE of upstream and cancels as soon as one arrives. The take, elemnentAt and firstXXX operators all have this counter-intuitive characteristic.
+     * <p>
+     * Righto, Fred now uses the new API like this:
      * 
-     * <p>Greta uses the new API like this:
+     * <pre>
+     * {
+     *     &#64;code
+     *     Movie top = mostPopularMovies().compose(Transformers.maxRequest(1)).first().blockingFirst();
+     * }
+     * </pre>
+     * <p>
+     * The use of maxRequest above may seem unnecessary but strangely enough the
+     * first operator requests Long.MAX_VALUE of upstream and cancels as soon as one
+     * arrives. The take, elemnentAt and firstXXX operators all have this
+     * counter-intuitive characteristic.
      * 
-     * <pre>{@code
+     * <p>
+     * Greta uses the new API like this:
+     * 
+     * <pre>
+     * {@code
      * mostPopularMovies()
      *     .rebatchRequests(20)
      *     .doOnNext(movie -> addToUI(movie))
      *     .subscribe(subscriber);
-     * }</pre>
-     * <p>A bit more detail about fetchPagesByRequest:
+     * }
+     * </pre>
+     * <p>
+     * A bit more detail about fetchPagesByRequest:
      * 
-     * <p>If the fetch function returns a Flowable that delivers fewer than the requested number of items then the overall stream completes.
+     * <p>
+     * If the fetch function returns a Flowable that delivers fewer than the
+     * requested number of items then the overall stream completes.
      * 
-     * @param fetch a function that takes a position index and a length and returns a Flowable
-     * @param start the start index
-     * @param maxConcurrent how many pages to request concurrently
-     * @param <T> item type
+     * @param fetch
+     *            a function that takes a position index and a length and returns a
+     *            Flowable
+     * @param start
+     *            the start index
+     * @param maxConcurrent
+     *            how many pages to request concurrently
+     * @param <T>
+     *            item type
      * @return Flowable that fetches pages based on request amounts
      */
-    public static <T> Flowable<T> fetchPagesByRequest(final BiFunction<? super Long, ? super Long, ? extends Flowable<T>> fetch,
-            long start, int maxConcurrent) {
+    public static <T> Flowable<T> fetchPagesByRequest(
+            final BiFunction<? super Long, ? super Long, ? extends Flowable<T>> fetch, long start, int maxConcurrent) {
         return FlowableFetchPagesByRequest.create(fetch, start, maxConcurrent);
     }
 
-    public static <T> Flowable<T> fetchPagesByRequest(final BiFunction<? super Long, ? super Long, ? extends Flowable<T>> fetch,
-            long start) {
+    public static <T> Flowable<T> fetchPagesByRequest(
+            final BiFunction<? super Long, ? super Long, ? extends Flowable<T>> fetch, long start) {
         return fetchPagesByRequest(fetch, start, 2);
     }
 
-    public static <T> Flowable<T> fetchPagesByRequest(final BiFunction<? super Long, ? super Long, ? extends Flowable<T>> fetch) {
+    public static <T> Flowable<T> fetchPagesByRequest(
+            final BiFunction<? super Long, ? super Long, ? extends Flowable<T>> fetch) {
         return fetchPagesByRequest(fetch, 0, 2);
     }
 
-
-
     /**
-     * Returns a cached {@link Flowable} like {@link Flowable#cache()}
-     * except that the cache can be reset by calling
-     * {@link CachedFlowable#reset()}.
+     * Returns a cached {@link Flowable} like {@link Flowable#cache()} except that
+     * the cache can be reset by calling {@link CachedFlowable#reset()}.
      *
      * @param source
      *            the observable to be cached.
@@ -142,11 +192,11 @@ public final class Flowables {
     }
 
     /**
-     * Returns a cached {@link Flowable} like {@link Flowable#cache()}
-     * except that the cache can be reset by calling
-     * {@link CachedFlowable#reset()} and the cache will be automatically
-     * reset an interval after first subscription (or first subscription after
-     * reset). The interval is defined by {@code duration} and {@code unit} .
+     * Returns a cached {@link Flowable} like {@link Flowable#cache()} except that
+     * the cache can be reset by calling {@link CachedFlowable#reset()} and the
+     * cache will be automatically reset an interval after first subscription (or
+     * first subscription after reset). The interval is defined by {@code duration}
+     * and {@code unit} .
      *
      * @param source
      *            the source observable
@@ -155,14 +205,14 @@ public final class Flowables {
      * @param unit
      *            units corresponding to the duration
      * @param worker
-     *            worker to use for scheduling reset. Don't forget to
-     *            unsubscribe the worker when no longer required.
+     *            worker to use for scheduling reset. Don't forget to unsubscribe
+     *            the worker when no longer required.
      * @param <T>
      *            the generic type of the source
      * @return cached observable that resets regularly on a time interval
      */
-    public static <T> Flowable<T> cache(final Flowable<T> source, final long duration,
-                                        final TimeUnit unit, final Scheduler.Worker worker) {
+    public static <T> Flowable<T> cache(final Flowable<T> source, final long duration, final TimeUnit unit,
+            final Scheduler.Worker worker) {
         final AtomicReference<CachedFlowable<T>> cacheRef = new AtomicReference<CachedFlowable<T>>();
         CachedFlowable<T> cache = new CachedFlowable<T>(source);
         cacheRef.set(cache);
@@ -181,8 +231,8 @@ public final class Flowables {
     }
 
     /**
-     * Returns a cached {@link Flowable} like {@link Flowable#cache()}
-     * except that the cache may be reset by the user calling
+     * Returns a cached {@link Flowable} like {@link Flowable#cache()} except that
+     * the cache may be reset by the user calling
      * {@link CloseableFlowableWithReset#reset}.
      *
      * @param source
@@ -198,11 +248,11 @@ public final class Flowables {
      * @return {@link CloseableFlowableWithReset} that should be closed once
      *         finished to prevent worker memory leak.
      */
-    public static <T> CloseableFlowableWithReset<T> cache(final Flowable<T> source,
-                                                          final long duration, final TimeUnit unit, final Scheduler scheduler) {
+    public static <T> CloseableFlowableWithReset<T> cache(final Flowable<T> source, final long duration,
+            final TimeUnit unit, final Scheduler scheduler) {
         final AtomicReference<CachedFlowable<T>> cacheRef = new AtomicReference<CachedFlowable<T>>();
         final AtomicReference<Optional<Scheduler.Worker>> workerRef = new AtomicReference<Optional<Scheduler.Worker>>(
-                Optional.<Scheduler.Worker> absent());
+                Optional.<Scheduler.Worker>absent());
         CachedFlowable<T> cache = new CachedFlowable<T>(source);
         cacheRef.set(cache);
         Runnable closeAction = new Runnable() {
@@ -237,10 +287,9 @@ public final class Flowables {
         return new CloseableFlowableWithReset<T>(cache, closeAction, resetAction);
     }
 
-
     private static <T> void startScheduledResetAgain(final long duration, final TimeUnit unit,
-                                                     final Scheduler scheduler, final AtomicReference<CachedFlowable<T>> cacheRef,
-                                                     final AtomicReference<Optional<Scheduler.Worker>> workerRef) {
+            final Scheduler scheduler, final AtomicReference<CachedFlowable<T>> cacheRef,
+            final AtomicReference<Optional<Scheduler.Worker>> workerRef) {
 
         Runnable action = new Runnable() {
             @Override
@@ -263,5 +312,9 @@ public final class Flowables {
                 break;
             }
         }
+    }
+
+    public static <T> Flowable<T> mergeInterleaved(Flowable<Flowable<T>> flowables, int maxConcurrency, int batchSize) {
+        return new FlowableMergeInterleave<T>(flowables, maxConcurrency, batchSize);
     }
 }

--- a/src/main/java/com/github/davidmoten/rx2/Flowables.java
+++ b/src/main/java/com/github/davidmoten/rx2/Flowables.java
@@ -3,6 +3,7 @@ package com.github.davidmoten.rx2;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 
+import org.reactivestreams.Publisher;
 import org.reactivestreams.Subscription;
 
 import com.github.davidmoten.guavamini.Optional;
@@ -324,29 +325,29 @@ public final class Flowables {
 
     private static final int DEFAULT_RING_BUFFER_SIZE = 128;
 
-    public static <T> Flowable<T> mergeInterleaved(Flowable<Flowable<T>> flowables,
+    public static <T> Flowable<T> mergeInterleaved(Publisher<? extends Publisher<? extends T>> publishers,
             int maxConcurrency, int batchSize, boolean delayErrors) {
-        return new FlowableMergeInterleave<T>(flowables, maxConcurrency, batchSize, delayErrors);
+        return new FlowableMergeInterleave<T>(publishers, maxConcurrency, batchSize, delayErrors);
     }
 
-    public static <T> Flowable<T> mergeInterleaved(Flowable<Flowable<T>> flowables,
+    public static <T> Flowable<T> mergeInterleaved(Publisher<? extends Publisher<? extends T>> publishers,
             int maxConcurrency) {
-        return new FlowableMergeInterleave<T>(flowables, maxConcurrency, 128, true);
+        return new FlowableMergeInterleave<T>(publishers, maxConcurrency, 128, true);
     }
 
-    public static <T> MergeInterleaveBuilder<T> mergeInterleaved(Flowable<Flowable<T>> flowables) {
-        return new MergeInterleaveBuilder<T>(flowables);
+    public static <T> MergeInterleaveBuilder<T> mergeInterleaved(Publisher<? extends Publisher<? extends T>> publishers) {
+        return new MergeInterleaveBuilder<T>(publishers);
     }
 
     public static final class MergeInterleaveBuilder<T> {
 
-        private Flowable<Flowable<T>> flowables;
+        private final Publisher<? extends Publisher<? extends T>> publishers;
         private int maxConcurrency = 4;
         private int batchSize = DEFAULT_RING_BUFFER_SIZE;
         private boolean delayErrors = false;
 
-        MergeInterleaveBuilder(Flowable<Flowable<T>> flowables) {
-            this.flowables = flowables;
+        MergeInterleaveBuilder(Publisher<? extends Publisher<? extends T>> publishers) {
+            this.publishers = publishers;
         }
 
         public MergeInterleaveBuilder<T> maxConcurrency(int maxConcurrency) {
@@ -365,7 +366,7 @@ public final class Flowables {
         }
 
         public Flowable<T> build() {
-            return mergeInterleaved(flowables, maxConcurrency, batchSize, delayErrors);
+            return mergeInterleaved(publishers, maxConcurrency, batchSize, delayErrors);
         }
     }
 }

--- a/src/main/java/com/github/davidmoten/rx2/Flowables.java
+++ b/src/main/java/com/github/davidmoten/rx2/Flowables.java
@@ -332,7 +332,7 @@ public final class Flowables {
 
     public static <T> Flowable<T> mergeInterleaved(Publisher<? extends Publisher<? extends T>> publishers,
             int maxConcurrency) {
-        return new FlowableMergeInterleave<T>(publishers, maxConcurrency, 128, true);
+        return mergeInterleaved(publishers, maxConcurrency, 128, false);
     }
 
     public static <T> MergeInterleaveBuilder<T> mergeInterleaved(Publisher<? extends Publisher<? extends T>> publishers) {

--- a/src/main/java/com/github/davidmoten/rx2/flowable/Transformers.java
+++ b/src/main/java/com/github/davidmoten/rx2/flowable/Transformers.java
@@ -19,7 +19,6 @@ import com.github.davidmoten.rx2.internal.flowable.FlowableDoOnEmpty;
 import com.github.davidmoten.rx2.internal.flowable.FlowableMapLast;
 import com.github.davidmoten.rx2.internal.flowable.FlowableMatch;
 import com.github.davidmoten.rx2.internal.flowable.FlowableMaxRequest;
-import com.github.davidmoten.rx2.internal.flowable.FlowableMergeInterleave;
 import com.github.davidmoten.rx2.internal.flowable.FlowableMinRequest;
 import com.github.davidmoten.rx2.internal.flowable.FlowableRepeatingTransform;
 import com.github.davidmoten.rx2.internal.flowable.FlowableReverse;

--- a/src/main/java/com/github/davidmoten/rx2/flowable/Transformers.java
+++ b/src/main/java/com/github/davidmoten/rx2/flowable/Transformers.java
@@ -440,4 +440,19 @@ public final class Transformers {
         return reduce(reducer, maxChained, Long.MAX_VALUE);
     }
 
+    public static <T, R> FlowableTransformer<T, R> flatMapInterleaved(final Function<? super T, ? extends Publisher<? extends R>> mapper,
+            final int maxConcurrency) {
+        return flatMapInterleaved(mapper, maxConcurrency, 128, false);
+    }
+    
+    public static <T, R> FlowableTransformer<T, R> flatMapInterleaved(final Function<? super T, ? extends Publisher<? extends R>> mapper,
+             final int maxConcurrency, final int bufferSize, final boolean delayErrors) {
+        return new FlowableTransformer<T, R>() {
+            @Override
+            public Publisher<R> apply(Flowable<T> f) {
+                return Flowables.mergeInterleaved(f.map(mapper), maxConcurrency, bufferSize, delayErrors);
+            }
+        };
+    }
+    
 }

--- a/src/main/java/com/github/davidmoten/rx2/flowable/Transformers.java
+++ b/src/main/java/com/github/davidmoten/rx2/flowable/Transformers.java
@@ -19,6 +19,7 @@ import com.github.davidmoten.rx2.internal.flowable.FlowableDoOnEmpty;
 import com.github.davidmoten.rx2.internal.flowable.FlowableMapLast;
 import com.github.davidmoten.rx2.internal.flowable.FlowableMatch;
 import com.github.davidmoten.rx2.internal.flowable.FlowableMaxRequest;
+import com.github.davidmoten.rx2.internal.flowable.FlowableMergeInterleave;
 import com.github.davidmoten.rx2.internal.flowable.FlowableMinRequest;
 import com.github.davidmoten.rx2.internal.flowable.FlowableRepeatingTransform;
 import com.github.davidmoten.rx2.internal.flowable.FlowableReverse;
@@ -62,12 +63,18 @@ public final class Transformers {
     }
 
     /**
-     * Returns a transformer that when a stream is empty runs the given {@link Action}.
+     * Returns a transformer that when a stream is empty runs the given
+     * {@link Action}.
      * 
-     * <p><img src="https://raw.githubusercontent.com/davidmoten/rxjava2-extras/master/src/docs/doOnEmpty.png" alt="image">
+     * <p>
+     * <img src=
+     * "https://raw.githubusercontent.com/davidmoten/rxjava2-extras/master/src/docs/doOnEmpty.png"
+     * alt="image">
      * 
-     * @param action to be called when the stream is determined to be empty.
-     * @param <T> item type
+     * @param action
+     *            to be called when the stream is determined to be empty.
+     * @param <T>
+     *            item type
      * 
      * @return a transformer that when a stream is empty runs the given action.
      */
@@ -138,12 +145,19 @@ public final class Transformers {
     }
 
     /**
-     * <p>Converts a stream of {@code Number} to a stream of {@link Statistics} about those numbers.
+     * <p>
+     * Converts a stream of {@code Number} to a stream of {@link Statistics} about
+     * those numbers.
      * 
-     * <p><img src="https://raw.githubusercontent.com/davidmoten/rxjava2-extras/master/src/docs/collectStats.png" alt="image">
+     * <p>
+     * <img src=
+     * "https://raw.githubusercontent.com/davidmoten/rxjava2-extras/master/src/docs/collectStats.png"
+     * alt="image">
      * 
-     * @param <T> item type
-     * @return transformer that converts a stream of Number to a stream of Statistics
+     * @param <T>
+     *            item type
+     * @return transformer that converts a stream of Number to a stream of
+     *         Statistics
      */
     @SuppressWarnings("unchecked")
     public static <T extends Number> FlowableTransformer<T, Statistics> collectStats() {
@@ -181,15 +195,25 @@ public final class Transformers {
      * Returns a transformer that emits collections of items with the collection
      * boundaries determined by the given {@link BiPredicate}.
      * 
-     * <p><img src="https://raw.githubusercontent.com/davidmoten/rxjava2-extras/master/src/docs/collectWhile.png" alt="image">
+     * <p>
+     * <img src=
+     * "https://raw.githubusercontent.com/davidmoten/rxjava2-extras/master/src/docs/collectWhile.png"
+     * alt="image">
      * 
-     * @param collectionFactory factory to create a new collection
-     * @param add method to add an item to a collection
-     * @param condition while true will continue to add to the current collection
-     * @param emitRemainder whether to emit the remainder as a collection
-     * @param <T> item type
-     * @param <R> collection type
-     * @return transform that collects while some conditions is returned then starts a new collection
+     * @param collectionFactory
+     *            factory to create a new collection
+     * @param add
+     *            method to add an item to a collection
+     * @param condition
+     *            while true will continue to add to the current collection
+     * @param emitRemainder
+     *            whether to emit the remainder as a collection
+     * @param <T>
+     *            item type
+     * @param <R>
+     *            collection type
+     * @return transform that collects while some conditions is returned then starts
+     *         a new collection
      */
     public static <T, R> FlowableTransformer<T, R> collectWhile(final Callable<R> collectionFactory,
             final BiFunction<? super R, ? super T, ? extends R> add, final BiPredicate<? super R, ? super T> condition,
@@ -416,4 +440,5 @@ public final class Transformers {
             final Function<? super Flowable<T>, ? extends Flowable<T>> reducer, final int maxChained) {
         return reduce(reducer, maxChained, Long.MAX_VALUE);
     }
+
 }

--- a/src/main/java/com/github/davidmoten/rx2/internal/flowable/FlowableMergeInterleave.java
+++ b/src/main/java/com/github/davidmoten/rx2/internal/flowable/FlowableMergeInterleave.java
@@ -41,9 +41,10 @@ public final class FlowableMergeInterleave<T> extends Flowable<T> {
         s.onSubscribe(subscription);
     }
 
-    private static final class MergeInterleaveSubscription<T>
+    private static final class MergeInterleaveSubscription<T> extends AtomicInteger
             implements Subscription, Subscriber<Flowable<T>> {
 
+        private static final long serialVersionUID = -6416801556759306113L;
         private static final Object SOURCES_COMPLETE = new Object();
         private final AtomicBoolean once = new AtomicBoolean();
         private final Flowable<Flowable<T>> sources;
@@ -56,7 +57,6 @@ public final class FlowableMergeInterleave<T> extends Flowable<T> {
         private Throwable error;
         private volatile boolean finished;
         private final AtomicLong requested = new AtomicLong();
-        private final AtomicInteger wip = new AtomicInteger();
         private long emitted;
         private final RingBuffer<BatchFinished> batchFinished;
 
@@ -134,7 +134,7 @@ public final class FlowableMergeInterleave<T> extends Flowable<T> {
 
         @SuppressWarnings("unchecked")
         private void drain() {
-            if (wip.getAndIncrement() == 0) {
+            if (getAndIncrement() == 0) {
                 int missed = 1;
                 long e = emitted;
                 long r = requested.get();
@@ -190,7 +190,7 @@ public final class FlowableMergeInterleave<T> extends Flowable<T> {
                         }
                     }
                     emitted = e;
-                    missed = wip.addAndGet(-missed);
+                    missed = addAndGet(-missed);
                     if (missed == 0) {
                         return;
                     }

--- a/src/main/java/com/github/davidmoten/rx2/internal/flowable/FlowableMergeInterleave.java
+++ b/src/main/java/com/github/davidmoten/rx2/internal/flowable/FlowableMergeInterleave.java
@@ -211,14 +211,7 @@ public final class FlowableMergeInterleave<T> extends Flowable<T> {
             if (!ok) {
                 throw new RuntimeException("ring buffer full!");
             }
-            while (true) {
-                BatchFinished s = batchFinished.poll();
-                if (s != null) {
-                    s.requestMore();
-                } else {
-                    break;
-                }
-            }
+            batchFinished.poll().requestMore();
         }
 
         private void cleanup() {

--- a/src/main/java/com/github/davidmoten/rx2/internal/flowable/FlowableMergeInterleave.java
+++ b/src/main/java/com/github/davidmoten/rx2/internal/flowable/FlowableMergeInterleave.java
@@ -24,20 +24,20 @@ public final class FlowableMergeInterleave<T> extends Flowable<T> {
     private final int maxConcurrent;
     private final Flowable<Flowable<T>> sources;
     private final int batchSize;
-    private boolean delayError;
+    private boolean delayErrors;
 
     public FlowableMergeInterleave(Flowable<Flowable<T>> sources, int maxConcurrent, int batchSize,
-            boolean delayError) {
+            boolean delayErrors) {
         this.sources = sources;
         this.maxConcurrent = maxConcurrent;
         this.batchSize = batchSize;
-        this.delayError = delayError;
+        this.delayErrors = delayErrors;
     }
 
     @Override
     protected void subscribeActual(Subscriber<? super T> s) {
         MergeInterleaveSubscription<T> subscription = new MergeInterleaveSubscription<T>(sources,
-                maxConcurrent, batchSize, delayError, s);
+                maxConcurrent, batchSize, delayErrors, s);
         s.onSubscribe(subscription);
     }
 
@@ -49,7 +49,7 @@ public final class FlowableMergeInterleave<T> extends Flowable<T> {
         private final Flowable<Flowable<T>> sources;
         private final int maxConcurrent;
         private final int batchSize;
-        private final boolean delayError;
+        private final boolean delayErrors;
         private Subscriber<? super T> subscriber;
         private Subscription subscription;
         private volatile boolean cancelled;
@@ -67,11 +67,11 @@ public final class FlowableMergeInterleave<T> extends Flowable<T> {
         private long sourcesCount;
 
         public MergeInterleaveSubscription(Flowable<Flowable<T>> sources, int maxConcurrent,
-                int batchSize, boolean delayError, Subscriber<? super T> subscriber) {
+                int batchSize, boolean delayErrors, Subscriber<? super T> subscriber) {
             this.sources = sources;
             this.maxConcurrent = maxConcurrent;
             this.batchSize = batchSize;
-            this.delayError = delayError;
+            this.delayErrors = delayErrors;
             this.subscriber = subscriber;
             this.queue = new MpscLinkedQueue<Object>();
             this.batchFinished = RingBuffer.create(maxConcurrent + 1);
@@ -147,7 +147,7 @@ public final class FlowableMergeInterleave<T> extends Flowable<T> {
                     }
                     while (e != r) {
                         boolean d = finished;
-                        if (d && !delayError) {
+                        if (d && !delayErrors) {
                             Throwable err = error;
                             if (err != null) {
                                 error = null;

--- a/src/main/java/com/github/davidmoten/rx2/internal/flowable/FlowableMergeInterleave.java
+++ b/src/main/java/com/github/davidmoten/rx2/internal/flowable/FlowableMergeInterleave.java
@@ -174,9 +174,9 @@ public final class FlowableMergeInterleave<T> extends Flowable<T> {
                             } else if (o instanceof SourceArrived) {
                                 handleSourceArrived((SourceArrived<T>) o);
                             } else if (o instanceof SourceComplete) {
-                                handleSourceTerminated((SourceComplete<T>) o);
+                                handleSourceComplete((SourceComplete<T>) o);
                             } else if (o == SOURCES_COMPLETE) {
-                                sourcesComplete = true;
+                                handleSourcesComplete();
                             } else {
                                 subscriber.onNext((T) o);
                                 e++;
@@ -192,6 +192,13 @@ public final class FlowableMergeInterleave<T> extends Flowable<T> {
                         return;
                     }
                 }
+            }
+        }
+
+        private void handleSourcesComplete() {
+            sourcesComplete = true;
+            if (sourceSubscribers.isEmpty()) {
+                finished = true;
             }
         }
 
@@ -225,12 +232,12 @@ public final class FlowableMergeInterleave<T> extends Flowable<T> {
             event.flowable.subscribe(subscriber);
         }
 
-        private void handleSourceTerminated(SourceComplete<T> event) {
+        private void handleSourceComplete(SourceComplete<T> event) {
             System.out.println(event.subscriber + " terminated");
             sourceSubscribers.remove(event.subscriber);
             if (!sourcesComplete) {
                 subscription.request(1);
-            } else if (sourceSubscribers.isEmpty()) {
+            } else if (sourceSubscribers.isEmpty() && sourcesComplete) {
                 finished = true;
             }
         }

--- a/src/main/java/com/github/davidmoten/rx2/internal/flowable/FlowableMergeInterleave.java
+++ b/src/main/java/com/github/davidmoten/rx2/internal/flowable/FlowableMergeInterleave.java
@@ -81,14 +81,12 @@ public final class FlowableMergeInterleave<T> extends Flowable<T> {
 
         @Override
         public void request(long n) {
-            System.out.println("request(" + n + ")");
             if (SubscriptionHelper.validate(n)) {
                 BackpressureHelper.add(requested, n);
                 if (once.compareAndSet(false, true)) {
                     sources.subscribe(this);
                     subscription.request(maxConcurrent);
                 }
-                System.out.println("requested = " + requested);
                 drain();
             }
         }
@@ -146,10 +144,6 @@ public final class FlowableMergeInterleave<T> extends Flowable<T> {
                         if (tryCancelled()) {
                             return;
                         }
-                        // if flowable on queue then subscribe to it
-                        // if flowable finished then request another
-                        // if subscriber has data or terminates then emit it round-robin style
-                        // subscribers should only request batchSize at a time
                         long r = requested.get();
                         long e = emitted;
                         while (e != r) {
@@ -291,7 +285,6 @@ public final class FlowableMergeInterleave<T> extends Flowable<T> {
 
         @Override
         public void onNext(T t) {
-            System.out.println(t);
             count++;
             boolean batchFinished = count == parent.batchSize;
             if (batchFinished) {
@@ -312,7 +305,6 @@ public final class FlowableMergeInterleave<T> extends Flowable<T> {
 
         @Override
         public void requestMore() {
-            System.out.println("requesting more from " + this);
             subscription.get().request(parent.batchSize);
         }
 

--- a/src/main/java/com/github/davidmoten/rx2/internal/flowable/FlowableMergeInterleave.java
+++ b/src/main/java/com/github/davidmoten/rx2/internal/flowable/FlowableMergeInterleave.java
@@ -226,11 +226,12 @@ public final class FlowableMergeInterleave<T> extends Flowable<T> {
         }
 
         private void handleSourceTerminated(SourceComplete<T> event) {
+            System.out.println(event.subscriber + " terminated");
             sourceSubscribers.remove(event.subscriber);
             if (!sourcesComplete) {
                 subscription.request(1);
             } else if (sourceSubscribers.isEmpty()) {
-                subscriber.onComplete();
+                finished = true;
             }
         }
 

--- a/src/main/java/com/github/davidmoten/rx2/internal/flowable/FlowableMergeInterleave.java
+++ b/src/main/java/com/github/davidmoten/rx2/internal/flowable/FlowableMergeInterleave.java
@@ -86,7 +86,7 @@ public final class FlowableMergeInterleave<T> extends Flowable<T> {
                 BackpressureHelper.add(requested, n);
                 if (once.compareAndSet(false, true)) {
                     sources.subscribe(this);
-                    subscription.request(maxConcurrent);                    
+                    subscription.request(maxConcurrent);
                 }
                 System.out.println("requested = " + requested);
                 drain();
@@ -151,7 +151,6 @@ public final class FlowableMergeInterleave<T> extends Flowable<T> {
                         // if subscriber has data or terminates then emit it round-robin style
                         // subscribers should only request batchSize at a time
                         long r = requested.get();
-                        System.out.println("requested=" + r);
                         long e = emitted;
                         while (e != r) {
                             T t = emissions.poll();
@@ -171,6 +170,9 @@ public final class FlowableMergeInterleave<T> extends Flowable<T> {
                             }
                         }
                         emitted = e;
+                        if (e == r) {
+                            break;
+                        }
                         boolean d = finished;
                         Object o = queue.poll();
                         if (o == null) {

--- a/src/main/java/com/github/davidmoten/rx2/internal/flowable/FlowableMergeInterleave.java
+++ b/src/main/java/com/github/davidmoten/rx2/internal/flowable/FlowableMergeInterleave.java
@@ -1,0 +1,312 @@
+package com.github.davidmoten.rx2.internal.flowable;
+
+import java.util.ArrayList;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Queue;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.atomic.AtomicReference;
+
+import org.reactivestreams.Subscriber;
+import org.reactivestreams.Subscription;
+
+import io.reactivex.Flowable;
+import io.reactivex.internal.fuseable.SimplePlainQueue;
+import io.reactivex.internal.queue.MpscLinkedQueue;
+import io.reactivex.internal.subscriptions.SubscriptionHelper;
+import io.reactivex.internal.util.BackpressureHelper;
+
+public final class FlowableMergeInterleave<T> extends Flowable<T> {
+
+    private final int maxConcurrent;
+    private final Flowable<Flowable<T>> sources;
+    private final int batchSize;
+
+    public FlowableMergeInterleave(Flowable<Flowable<T>> sources, int maxConcurrent, int batchSize) {
+        this.sources = sources;
+        this.maxConcurrent = maxConcurrent;
+        this.batchSize = batchSize;
+    }
+
+    @Override
+    protected void subscribeActual(Subscriber<? super T> s) {
+        MergeInterleaveSubscription<T> subscription = new MergeInterleaveSubscription<T>(sources, maxConcurrent,
+                batchSize, s);
+        s.onSubscribe(subscription);
+    }
+
+    private static final class MergeInterleaveSubscription<T> implements Subscription, Subscriber<Flowable<T>> {
+
+        private static final Object SOURCES_COMPLETE = new Object();
+        private final AtomicBoolean once = new AtomicBoolean();
+        private final Flowable<Flowable<T>> sources;
+        private final int maxConcurrent;
+        private Subscriber<? super T> subscriber;
+        private Subscription subscription;
+        private volatile boolean cancelled;
+        private Throwable error;
+        private volatile boolean finished;
+        private final AtomicLong requested = new AtomicLong();
+        private final AtomicInteger wip = new AtomicInteger();
+        private final Queue<T> emissions = new LinkedList<T>();
+        private long emitted;
+
+        // objects on queue can be Flowable, Subscriber,
+        private final SimplePlainQueue<Object> queue;
+        private final int batchSize;
+        private final List<SourceSubscriber<T>> sourceSubscribers = new ArrayList<SourceSubscriber<T>>();
+        private int sourceSubscriberIndex;
+        private boolean sourcesComplete;
+        private boolean allEmissionsComplete;
+
+        public MergeInterleaveSubscription(Flowable<Flowable<T>> sources, int maxConcurrent, int batchSize,
+                Subscriber<? super T> subscriber) {
+            this.sources = sources;
+            this.maxConcurrent = maxConcurrent;
+            this.batchSize = batchSize;
+            this.subscriber = subscriber;
+            this.queue = new MpscLinkedQueue<Object>();
+        }
+
+        @Override
+        public void request(long n) {
+            if (SubscriptionHelper.validate(n)) {
+                if (once.compareAndSet(false, true)) {
+                    sources.subscribe(this);
+                }
+                BackpressureHelper.produced(requested, n);
+                drain();
+            }
+        }
+
+        @Override
+        public void cancel() {
+            this.cancelled = true;
+        }
+
+        @Override
+        public void onSubscribe(Subscription s) {
+            this.subscription = s;
+            s.request(maxConcurrent);
+            drain();
+        }
+
+        @Override
+        public void onNext(Flowable<T> f) {
+            queue.offer(new SourceArrived<T>(f));
+            drain();
+        }
+
+        @Override
+        public void onError(Throwable t) {
+            error = t;
+            finished = true;
+            drain();
+        }
+
+        @Override
+        public void onComplete() {
+            queue.offer(SOURCES_COMPLETE);
+            drain();
+        }
+
+        private boolean tryCancelled() {
+            if (cancelled) {
+                subscription.cancel();
+                queue.clear();
+                emissions.clear();
+                return true;
+            } else {
+                return false;
+            }
+        }
+
+        @SuppressWarnings("unchecked")
+        private void drain() {
+            if (wip.getAndIncrement() == 0) {
+                int missed = 1;
+                while (true) {
+                    long r = requested.get();
+                    while (true) {
+                        if (tryCancelled()) {
+                            return;
+                        }
+                        // if flowable on queue then subscribe to it
+                        // if flowable finished then request another
+                        // if subscriber has data or terminates then emit it round-robin style
+                        // subscribers should only request batchSize at a time
+                        long e = emitted;
+                        while (e != r) {
+                            T t = emissions.poll();
+                            if (t != null) {
+                                subscriber.onNext(t);
+                                e++;
+                            } else {
+                                if (allEmissionsComplete) {
+                                    subscriber.onComplete();
+                                    return;
+                                } else {
+                                    break;
+                                }
+                            }
+                            if (tryCancelled()) {
+                                return;
+                            }
+                        }
+                        emitted = e;
+                        boolean d = finished;
+                        Object o = queue.poll();
+                        System.out.println("drained " + o);
+                        if (o == null) {
+                            if (d) {
+                                Throwable err = error;
+                                if (err != null) {
+                                    error = null;
+                                    cleanup();
+                                    subscriber.onError(err);
+                                } else {
+                                    subscriber.onComplete();
+                                }
+                                return;
+                            } else {
+                                break;
+                            }
+                        } else {
+                            if (o instanceof BatchFinished) {
+                                handleBatchFinished((BatchFinished) o);
+                            } else if (o instanceof SourceArrived) {
+                                handleSource((SourceArrived<T>) o);
+                            } else if (o instanceof SourceComplete) {
+                                handleSourceTerminated((SourceComplete<T>) o);
+                            } else if (o == SOURCES_COMPLETE) {
+                                sourcesComplete = true;
+                            } else {
+                                // is emission
+                                emissions.offer((T) o);
+                            }
+                        }
+                        if (tryCancelled()) {
+                            return;
+                        }
+                    }
+                    missed = wip.addAndGet(-missed);
+                    if (missed == 0) {
+                        return;
+                    }
+                }
+            }
+        }
+
+        @SuppressWarnings("unchecked")
+        private void handleBatchFinished(BatchFinished b) {
+            SourceSubscriber<T> sub = (SourceSubscriber<T>) b;
+            sub.requestMore();
+        }
+
+        private void cleanup() {
+            for (SourceSubscriber<T> s : sourceSubscribers) {
+                s.cancel();
+            }
+        }
+
+        private void handleSource(SourceArrived<T> event) {
+            SourceSubscriber<T> subscriber = new SourceSubscriber<T>(this);
+            sourceSubscribers.add(subscriber);
+            event.flowable.subscribe(subscriber);
+        }
+
+        private void handleSourceTerminated(SourceComplete<T> event) {
+            int i = sourceSubscribers.indexOf(event.subscriber);
+            if (i >= sourceSubscriberIndex) {
+                sourceSubscriberIndex--;
+            }
+            sourceSubscribers.remove(event.subscriber);
+            if (!sourcesComplete) {
+                subscription.request(1);
+            } else if (sourceSubscribers.isEmpty()) {
+                allEmissionsComplete = true;
+            }
+        }
+
+    }
+
+    private final static class SourceSubscriber<T> implements Subscriber<T>, BatchFinished {
+
+        private final MergeInterleaveSubscription<T> parent;
+        private AtomicReference<Subscription> subscription = new AtomicReference<Subscription>();
+        private int count = 0;
+
+        SourceSubscriber(MergeInterleaveSubscription<T> parent) {
+            this.parent = parent;
+        }
+
+        @Override
+        public void onSubscribe(Subscription s) {
+            SubscriptionHelper.setOnce(subscription, s);
+            requestMore();
+        }
+
+        @Override
+        public void onNext(T t) {
+            count++;
+            parent.queue.offer(t);
+            if (count == parent.batchSize) {
+                // offer batch finished indicator
+                parent.queue.offer(this);
+                count = 0;
+            }
+            parent.drain();
+        }
+
+        @Override
+        public void onError(Throwable t) {
+            parent.error = t;
+            parent.finished = true;
+            parent.drain();
+        }
+
+        @Override
+        public void onComplete() {
+            parent.queue.offer(new SourceComplete<T>(this));
+            parent.drain();
+        }
+        
+        void requestMore() {
+            subscription.get().request(parent.batchSize);
+        }
+
+        void cancel() {
+            while (true) {
+                Subscription s = subscription.get();
+                if (subscription.compareAndSet(s, SubscriptionHelper.CANCELLED)) {
+                    s.cancel();
+                    break;
+                }
+            }
+        }
+
+    }
+
+    private static final class SourceArrived<T> {
+        final Flowable<T> flowable;
+
+        SourceArrived(Flowable<T> flowable) {
+            this.flowable = flowable;
+        }
+    }
+
+    private static final class SourceComplete<T> {
+        final Subscriber<T> subscriber;
+
+        SourceComplete(Subscriber<T> subscriber) {
+            this.subscriber = subscriber;
+        }
+    }
+
+    private interface BatchFinished {
+
+    }
+
+}

--- a/src/main/java/com/github/davidmoten/rx2/internal/flowable/FlowableMergeInterleave.java
+++ b/src/main/java/com/github/davidmoten/rx2/internal/flowable/FlowableMergeInterleave.java
@@ -211,7 +211,6 @@ public final class FlowableMergeInterleave<T> extends Flowable<T> {
             if (!ok) {
                 throw new RuntimeException("ring buffer full!");
             }
-            System.out.println("batchFinished=" + batchFinished);
             while (true) {
                 BatchFinished s = batchFinished.poll();
                 if (s != null) {
@@ -236,7 +235,6 @@ public final class FlowableMergeInterleave<T> extends Flowable<T> {
         }
 
         private void handleSourceComplete(SourceComplete<T> event) {
-            System.out.println(event.subscriber + " terminated");
             sourceSubscribers.remove(event.subscriber);
             if (!sourcesComplete) {
                 subscription.request(1);
@@ -258,10 +256,8 @@ public final class FlowableMergeInterleave<T> extends Flowable<T> {
 
         public void sourceNext(T t, SourceSubscriber<T> sourceSubscriber) {
             queue.offer(t);
-            System.out.println("value on queue " + t);
             if (sourceSubscriber != null) {
                 queue.offer(sourceSubscriber);
-                System.out.println(sourceSubscriber + " batch finished on queue");
             }
             drain();
         }
@@ -304,13 +300,11 @@ public final class FlowableMergeInterleave<T> extends Flowable<T> {
 
         @Override
         public void onComplete() {
-            System.out.println("COMPLETE");
             parent.sourceComplete(this);
         }
 
         @Override
         public void requestMore() {
-            System.out.println(this + " requesting more ");
             subscription.get().request(parent.batchSize);
         }
 

--- a/src/main/java/com/github/davidmoten/rx2/internal/flowable/FlowableMergeInterleave.java
+++ b/src/main/java/com/github/davidmoten/rx2/internal/flowable/FlowableMergeInterleave.java
@@ -64,7 +64,7 @@ public final class FlowableMergeInterleave<T> extends Flowable<T> {
         private final SimplePlainQueue<Object> queue;
         private final List<SourceSubscriber<T>> sourceSubscribers = new ArrayList<SourceSubscriber<T>>();
         private boolean sourcesComplete;
-        private int sourcesCount;
+        private long sourcesCount;
 
         public MergeInterleaveSubscription(Flowable<Flowable<T>> sources, int maxConcurrent,
                 int batchSize, boolean delayError, Subscriber<? super T> subscriber) {
@@ -137,11 +137,14 @@ public final class FlowableMergeInterleave<T> extends Flowable<T> {
             if (wip.getAndIncrement() == 0) {
                 int missed = 1;
                 long e = emitted;
+                long r = requested.get();
                 while (true) {
                     if (tryCancelled()) {
                         return;
                     }
-                    long r = requested.get();
+                    if (e == r) {
+                        r = requested.get();
+                    }
                     while (e != r) {
                         boolean d = finished;
                         if (d && !delayError) {

--- a/src/main/java/com/github/davidmoten/rx2/internal/flowable/FlowableMergeInterleave.java
+++ b/src/main/java/com/github/davidmoten/rx2/internal/flowable/FlowableMergeInterleave.java
@@ -274,11 +274,6 @@ public final class FlowableMergeInterleave<T> extends Flowable<T> {
         }
 
         @Override
-        public String toString() {
-            return "SourceSubscriber-" + hashCode();
-        }
-
-        @Override
         public void onSubscribe(Subscription s) {
             SubscriptionHelper.setOnce(subscription, s);
         }

--- a/src/main/java/com/github/davidmoten/rx2/internal/flowable/RingBuffer.java
+++ b/src/main/java/com/github/davidmoten/rx2/internal/flowable/RingBuffer.java
@@ -1,0 +1,172 @@
+package com.github.davidmoten.rx2.internal.flowable;
+
+import java.util.Collection;
+import java.util.Iterator;
+import java.util.NoSuchElementException;
+import java.util.Queue;
+
+/**
+ * Non-threadsafe implementation of a Ring Buffer. Does not accept nulls.
+ * 
+ * @param <T>
+ */
+// @NotThreadSafe
+public class RingBuffer<T> implements Queue<T> {
+
+    private final T[] list;
+    private int start;
+    private int finish;
+
+    @SuppressWarnings("unchecked")
+    private RingBuffer(int size) {
+        list = (T[]) new Object[size + 1];
+    }
+
+    public static <T> RingBuffer<T> create(int size) {
+        return new RingBuffer<T>(size);
+    }
+
+    @Override
+    public void clear() {
+        finish = start;
+    }
+
+    @Override
+    public Iterator<T> iterator() {
+        final int _start = start;
+        final int _finish = finish;
+        return new Iterator<T>() {
+            int i = _start;
+
+            @Override
+            public boolean hasNext() {
+                return i != _finish;
+            }
+
+            @Override
+            public T next() {
+                T value = list[i];
+                i = (i + 1) % list.length;
+                return value;
+            }
+        };
+    }
+
+    @Override
+    public T peek() {
+        if (start == finish)
+            return null;
+        else
+            return list[start];
+    }
+
+    public boolean isEmpty() {
+        return start == finish;
+    }
+
+    public int size() {
+        if (start <= finish)
+            return finish - start;
+        else
+            return finish - start + list.length;
+    }
+
+    public int maxSize() {
+        return list.length - 1;
+    }
+
+    @Override
+    public boolean contains(Object o) {
+        return notImplemented();
+    }
+
+    @Override
+    public Object[] toArray() {
+        return notImplemented();
+    }
+
+    @Override
+    public <S> S[] toArray(S[] a) {
+        return notImplemented();
+    }
+
+    @Override
+    public boolean remove(Object o) {
+        return notImplemented();
+    }
+
+    @Override
+    public boolean containsAll(Collection<?> c) {
+        return notImplemented();
+    }
+
+    private static <T> T notImplemented() {
+        throw new RuntimeException("Not implemented");
+    }
+
+    @Override
+    public boolean addAll(Collection<? extends T> c) {
+        for (T t : c)
+            add(t);
+        return true;
+    }
+
+    @Override
+    public boolean removeAll(Collection<?> c) {
+        return notImplemented();
+    }
+
+    @Override
+    public boolean retainAll(Collection<?> c) {
+        return notImplemented();
+    }
+
+    @Override
+    public boolean add(T t) {
+        if (offer(t))
+            return true;
+        else
+            throw new IllegalStateException("Cannot add to queue because is full");
+    }
+
+    @Override
+    public boolean offer(T t) {
+        if (t == null)
+            throw new NullPointerException();
+        int currentFinish = finish;
+        finish = (finish + 1) % list.length;
+        if (finish == start) {
+            return false;
+        } else {
+            list[currentFinish] = t;
+            return true;
+        }
+    }
+
+    @Override
+    public T remove() {
+        T t = poll();
+        if (t == null)
+            throw new NoSuchElementException();
+        else
+            return t;
+    }
+
+    @Override
+    public T poll() {
+        if (start == finish) {
+            return null;
+        } else {
+            T value = list[start];
+            // don't hold a reference to a popped value
+            list[start] = null;
+            start = (start + 1) % list.length;
+            return value;
+        }
+    }
+
+    @Override
+    public T element() {
+        return notImplemented();
+    }
+}

--- a/src/main/java/com/github/davidmoten/util/RingBuffer.java
+++ b/src/main/java/com/github/davidmoten/util/RingBuffer.java
@@ -169,4 +169,21 @@ public class RingBuffer<T> implements Queue<T> {
     public T element() {
         return notImplemented();
     }
+    
+    @Override
+    public String toString() {
+        StringBuilder s = new StringBuilder();
+        s.append("RingBuffer[");
+        boolean first = true;
+        for (T value: this) {
+            if (!first) {
+                s.append(", ");
+            } else {
+                first = false;
+            }
+            s.append(String.valueOf(value));
+        }
+        s.append("]");
+        return s.toString();
+    }
 }

--- a/src/main/java/com/github/davidmoten/util/RingBuffer.java
+++ b/src/main/java/com/github/davidmoten/util/RingBuffer.java
@@ -1,4 +1,4 @@
-package com.github.davidmoten.rx2.internal.flowable;
+package com.github.davidmoten.util;
 
 import java.util.Collection;
 import java.util.Iterator;

--- a/src/test/java/com/github/davidmoten/rx2/Benchmarks.java
+++ b/src/test/java/com/github/davidmoten/rx2/Benchmarks.java
@@ -62,7 +62,7 @@ public class Benchmarks {
                         public void accept(Emitter<Integer> emitter) throws Exception {
                             count[0]++;
                             emitter.onNext(count[0]);
-                            if (count[0] == 100000) {
+                            if (count[0] == 1000) {
                                 emitter.onComplete();
                             }
                         }
@@ -117,8 +117,6 @@ public class Benchmarks {
     }
 
     public static void main(String[] args) {
-        while (true) {
-            source.compose(Strings.splitSimple("\n")).blockingLast();
-        }
+        range.doOnNext(Consumers.println()).subscribe();
     }
 }

--- a/src/test/java/com/github/davidmoten/rx2/Benchmarks.java
+++ b/src/test/java/com/github/davidmoten/rx2/Benchmarks.java
@@ -53,11 +53,11 @@ public class Benchmarks {
 
     private static Flowable<Integer> range = Flowable
             .defer(new Callable<Publisher<? extends Integer>>() {
-                final int[] count = new int[1];
-
                 @Override
                 public Publisher<? extends Integer> call() throws Exception {
                     return Flowable.generate(new Consumer<Emitter<Integer>>() {
+                        final int[] count = new int[1];
+
                         @Override
                         public void accept(Emitter<Integer> emitter) throws Exception {
                             count[0]++;
@@ -117,6 +117,6 @@ public class Benchmarks {
     }
 
     public static void main(String[] args) {
-        range.doOnNext(Consumers.println()).subscribe();
+        new Benchmarks().mergeTwoStreams();
     }
 }

--- a/src/test/java/com/github/davidmoten/rx2/Benchmarks.java
+++ b/src/test/java/com/github/davidmoten/rx2/Benchmarks.java
@@ -1,5 +1,6 @@
 package com.github.davidmoten.rx2;
 
+import java.util.Arrays;
 import java.util.regex.Pattern;
 
 import org.openjdk.jmh.annotations.Benchmark;
@@ -45,6 +46,23 @@ public class Benchmarks {
     @Benchmark
     public String splitSimple() {
         return source.compose(Strings.splitSimple("\n")).blockingLast();
+    }
+
+    @Benchmark
+    public Long mergeTwoStreams() {
+        Flowable<Integer> a = Flowable.range(0, 100000);
+        return Flowable.merge(Flowable.just(a, a, a)).count().blockingGet();
+    }
+
+    @Benchmark
+    public Long mergeTwoStreamsInterleaved() {
+        Flowable<Integer> a = Flowable.range(0, 100000);
+        return Flowables.mergeInterleaved(Flowable.just(a, a, a)) //
+                .maxConcurrency(4) //
+                .batchSize(128) //
+                .build() //
+                .count() //
+                .blockingGet();
     }
 
     @Benchmark

--- a/src/test/java/com/github/davidmoten/rx2/internal/flowable/FlowableMergeInterleavedTest.java
+++ b/src/test/java/com/github/davidmoten/rx2/internal/flowable/FlowableMergeInterleavedTest.java
@@ -1,11 +1,13 @@
 package com.github.davidmoten.rx2.internal.flowable;
 
+import org.junit.Ignore;
 import org.junit.Test;
 
 import com.github.davidmoten.rx2.Consumers;
 import com.github.davidmoten.rx2.Flowables;
 
 import io.reactivex.Flowable;
+import io.reactivex.schedulers.Schedulers;
 
 public final class FlowableMergeInterleavedTest {
 
@@ -147,6 +149,17 @@ public final class FlowableMergeInterleavedTest {
                 .test() //
                 .assertNoValues() //
                 .assertError(e);
+    }
+
+    @Test
+    @Ignore
+    public void testInterleaveAsync() {
+        Flowable<Integer> a = Flowable.just(1).repeat(100).subscribeOn(Schedulers.io());
+        Flowable<Integer> b = Flowable.just(2).repeat(100);
+        Flowables.mergeInterleaved(Flowable.just(a, b), 2, 2, true) //
+                .test() //
+                .assertValueCount(200) //
+                .assertComplete();
     }
 
 }

--- a/src/test/java/com/github/davidmoten/rx2/internal/flowable/FlowableMergeInterleavedTest.java
+++ b/src/test/java/com/github/davidmoten/rx2/internal/flowable/FlowableMergeInterleavedTest.java
@@ -149,11 +149,15 @@ public class FlowableMergeInterleavedTest {
         Flowable<Integer> a = Flowable.just(1, 1, 1);
         RuntimeException e = new RuntimeException();
         Flowable<Integer> b = Flowable.error(e);
-        Flowables.mergeInterleaved(Flowable.just(a, b), 2, 1, false) //
+        Flowables.mergeInterleaved(Flowable.just(a, b)) //
+                .maxConcurrency(2) //
+                .batchSize(1) //
+                .delayErrors(false) //
+                .build() //
                 .doOnNext(Consumers.println()) //
                 .test() //
                 .assertNoValues() //
                 .assertError(e);
     }
-    
+
 }

--- a/src/test/java/com/github/davidmoten/rx2/internal/flowable/FlowableMergeInterleavedTest.java
+++ b/src/test/java/com/github/davidmoten/rx2/internal/flowable/FlowableMergeInterleavedTest.java
@@ -177,4 +177,9 @@ public final class FlowableMergeInterleavedTest {
                 .assertNotTerminated();
     }
 
+    
+    @Test
+    public void testInterleaveCancelSources() {
+        //TODO
+    }
 }

--- a/src/test/java/com/github/davidmoten/rx2/internal/flowable/FlowableMergeInterleavedTest.java
+++ b/src/test/java/com/github/davidmoten/rx2/internal/flowable/FlowableMergeInterleavedTest.java
@@ -1,6 +1,5 @@
 package com.github.davidmoten.rx2.internal.flowable;
 
-import org.junit.Ignore;
 import org.junit.Test;
 
 import com.github.davidmoten.rx2.Consumers;
@@ -11,7 +10,6 @@ import io.reactivex.Flowable;
 public class FlowableMergeInterleavedTest {
 
     @Test
-    @Ignore
     public void testInterleave() {
         Flowable<Integer> a = Flowable.just(1).repeat();
         Flowable<Integer> b = Flowable.just(2).repeat();

--- a/src/test/java/com/github/davidmoten/rx2/internal/flowable/FlowableMergeInterleavedTest.java
+++ b/src/test/java/com/github/davidmoten/rx2/internal/flowable/FlowableMergeInterleavedTest.java
@@ -1,6 +1,5 @@
 package com.github.davidmoten.rx2.internal.flowable;
 
-import org.junit.Ignore;
 import org.junit.Test;
 
 import com.github.davidmoten.rx2.Consumers;
@@ -14,9 +13,11 @@ public class FlowableMergeInterleavedTest {
     public void testInterleave() {
         Flowable<Integer> a = Flowable.just(1).repeat();
         Flowable<Integer> b = Flowable.just(2).repeat();
-        Flowables.mergeInterleaved(Flowable.just(a, b), 2, 4) //
+        Flowables.mergeInterleaved(Flowable.just(a, b), 2, 2) //
                 .doOnNext(Consumers.println()) //
-                .test(24);
+                .test(4)
+                .assertValues(1, 1, 2, 2)
+                .assertNotTerminated();
     }
 
 }

--- a/src/test/java/com/github/davidmoten/rx2/internal/flowable/FlowableMergeInterleavedTest.java
+++ b/src/test/java/com/github/davidmoten/rx2/internal/flowable/FlowableMergeInterleavedTest.java
@@ -87,12 +87,34 @@ public class FlowableMergeInterleavedTest {
     
     @Test
     public void testInterleaveTwoCompletingStreamsSameSize() {
-        Flowable<Integer> a = Flowable.just(1, 1, 1);
-        Flowable<Integer> b = Flowable.just(2, 2, 2);
+        Flowable<Integer> a = Flowable.just(1, 1);
+        Flowable<Integer> b = Flowable.just(2, 2);
         Flowables.mergeInterleaved(Flowable.just(a, b), 2, 1, true) //
                 .doOnNext(Consumers.println()) //
                 .test() //
-                .assertValues(1, 2, 1, 2, 1, 2) //
+                .assertValues(1, 2, 1, 2) //
+                .assertComplete();
+    }
+    
+    @Test
+    public void testInterleaveCompletingStreamsDifferentSize() {
+        Flowable<Integer> a = Flowable.just(1, 1, 1);
+        Flowable<Integer> b = Flowable.just(2, 2);
+        Flowables.mergeInterleaved(Flowable.just(a, b), 2, 1, true) //
+                .doOnNext(Consumers.println()) //
+                .test() //
+                .assertValues(1, 2, 1, 2, 1) //
+                .assertComplete();
+    }
+    
+    @Test
+    public void testInterleaveCompletingStreamsWithEmpty() {
+        Flowable<Integer> a = Flowable.just(1, 1, 1);
+        Flowable<Integer> b = Flowable.empty();
+        Flowables.mergeInterleaved(Flowable.just(a, b), 2, 1, true) //
+                .doOnNext(Consumers.println()) //
+                .test() //
+                .assertValues(1, 1, 1) //
                 .assertComplete();
     }
 

--- a/src/test/java/com/github/davidmoten/rx2/internal/flowable/FlowableMergeInterleavedTest.java
+++ b/src/test/java/com/github/davidmoten/rx2/internal/flowable/FlowableMergeInterleavedTest.java
@@ -177,9 +177,26 @@ public final class FlowableMergeInterleavedTest {
                 .assertNotTerminated();
     }
 
-    
     @Test
-    public void testInterleaveCancelSources() {
-        //TODO
+    public void testSourcesError() {
+        RuntimeException ex = new RuntimeException("boo");
+        Flowables.mergeInterleaved(Flowable.<Flowable<Integer>>error(ex)) //
+                .build() //
+                .test() //
+                .assertNoValues() //
+                .assertError(ex);
+    }
+
+    @Test
+    public void testManySources() {
+        //one million sources
+        int n = 1000000;
+        Flowables.mergeInterleaved(Flowable.just(Flowable.just(1)).repeat(n)) //
+                .batchSize(2) //
+                .maxConcurrency(3) //
+                .build() //
+                .count() //
+                .test() //
+                .assertValue((long) n);
     }
 }

--- a/src/test/java/com/github/davidmoten/rx2/internal/flowable/FlowableMergeInterleavedTest.java
+++ b/src/test/java/com/github/davidmoten/rx2/internal/flowable/FlowableMergeInterleavedTest.java
@@ -14,7 +14,6 @@ public final class FlowableMergeInterleavedTest {
         Flowable<Integer> a = Flowable.just(1).repeat();
         Flowable<Integer> b = Flowable.just(2).repeat();
         Flowables.mergeInterleaved(Flowable.just(a, b), 2, 2, true) //
-                .doOnNext(Consumers.println()) //
                 .test(4) //
                 .assertValues(1, 1, 2, 2) //
                 .assertNotTerminated();
@@ -25,7 +24,6 @@ public final class FlowableMergeInterleavedTest {
         Flowable<Integer> a = Flowable.just(1).repeat();
         Flowable<Integer> b = Flowable.just(2).repeat();
         Flowables.mergeInterleaved(Flowable.just(a, b), 2, 2, true) //
-                .doOnNext(Consumers.println()) //
                 .test(1) //
                 .assertValues(1) //
                 .assertNotTerminated();
@@ -36,7 +34,6 @@ public final class FlowableMergeInterleavedTest {
         Flowable<Integer> a = Flowable.just(1).repeat();
         Flowable<Integer> b = Flowable.just(2).repeat();
         Flowables.mergeInterleaved(Flowable.just(a, b), 2, 1, true) //
-                .doOnNext(Consumers.println()) //
                 .test(5) //
                 .assertValues(1, 2, 1, 2, 1) //
                 .assertNotTerminated();
@@ -46,7 +43,6 @@ public final class FlowableMergeInterleavedTest {
     public void testInterleaveOneStream() {
         Flowable<Integer> a = Flowable.just(1).repeat(6);
         Flowables.mergeInterleaved(Flowable.just(a), 2, 2, true) //
-                .doOnNext(Consumers.println()) //
                 .test(3) //
                 .assertValues(1, 1, 1) //
                 .assertNotTerminated() //
@@ -71,7 +67,6 @@ public final class FlowableMergeInterleavedTest {
         Flowable<Integer> a = Flowable.just(1).repeat();
         Flowable<Integer> b = Flowable.just(2, 2);
         Flowables.mergeInterleaved(Flowable.just(a, b), 2, 1, true) //
-                .doOnNext(Consumers.println()) //
                 .test(6) //
                 .assertValues(1, 2, 1, 2, 1, 1) //
                 .assertNotTerminated();
@@ -82,7 +77,6 @@ public final class FlowableMergeInterleavedTest {
         Flowable<Integer> a = Flowable.just(1).repeat();
         Flowable<Integer> b = Flowable.never();
         Flowables.mergeInterleaved(Flowable.just(a, b), 2, 1, true) //
-                .doOnNext(Consumers.println()) //
                 .test(3) //
                 .assertValues(1, 1, 1) //
                 .assertNotTerminated();
@@ -93,7 +87,6 @@ public final class FlowableMergeInterleavedTest {
         Flowable<Integer> a = Flowable.never();
         Flowable<Integer> b = Flowable.just(1).repeat();
         Flowables.mergeInterleaved(Flowable.just(a, b), 2, 1, true) //
-                .doOnNext(Consumers.println()) //
                 .test(3) //
                 .assertValues(1, 1, 1) //
                 .assertNotTerminated();
@@ -104,7 +97,6 @@ public final class FlowableMergeInterleavedTest {
         Flowable<Integer> a = Flowable.just(1, 1);
         Flowable<Integer> b = Flowable.just(2, 2);
         Flowables.mergeInterleaved(Flowable.just(a, b), 2, 1, true) //
-                .doOnNext(Consumers.println()) //
                 .test() //
                 .assertValues(1, 2, 1, 2) //
                 .assertComplete();
@@ -115,7 +107,6 @@ public final class FlowableMergeInterleavedTest {
         Flowable<Integer> a = Flowable.just(1, 1, 1);
         Flowable<Integer> b = Flowable.just(2, 2);
         Flowables.mergeInterleaved(Flowable.just(a, b), 2, 1, true) //
-                .doOnNext(Consumers.println()) //
                 .test() //
                 .assertValues(1, 2, 1, 2, 1) //
                 .assertComplete();
@@ -126,7 +117,6 @@ public final class FlowableMergeInterleavedTest {
         Flowable<Integer> a = Flowable.just(1, 1, 1);
         Flowable<Integer> b = Flowable.empty();
         Flowables.mergeInterleaved(Flowable.just(a, b), 2, 1, true) //
-                .doOnNext(Consumers.println()) //
                 .test() //
                 .assertValues(1, 1, 1) //
                 .assertComplete();
@@ -138,7 +128,6 @@ public final class FlowableMergeInterleavedTest {
         RuntimeException e = new RuntimeException();
         Flowable<Integer> b = Flowable.error(e);
         Flowables.mergeInterleaved(Flowable.just(a, b), 2, 1, true) //
-                .doOnNext(Consumers.println()) //
                 .test() //
                 .assertValues(1, 1, 1) //
                 .assertError(e);

--- a/src/test/java/com/github/davidmoten/rx2/internal/flowable/FlowableMergeInterleavedTest.java
+++ b/src/test/java/com/github/davidmoten/rx2/internal/flowable/FlowableMergeInterleavedTest.java
@@ -9,15 +9,17 @@ import io.reactivex.Flowable;
 
 public class FlowableMergeInterleavedTest {
 
-    @Test(timeout = 3000)
-    public void testInterleave() {
+    @Test
+    public void testInterleaveTwoInfiniteStreams() {
         Flowable<Integer> a = Flowable.just(1).repeat();
         Flowable<Integer> b = Flowable.just(2).repeat();
-        Flowables.mergeInterleaved(Flowable.just(a, b), 2, 2) //
+        Flowables.mergeInterleaved(Flowable.just(a, b), 2, 2, true) //
                 .doOnNext(Consumers.println()) //
                 .test(4)
                 .assertValues(1, 1, 2, 2)
-                .assertNotTerminated();
+                .assertNotTerminated()
+                .requestMore(3) //
+                .assertValues(1, 1, 2, 2, 1, 1, 2);
     }
 
 }

--- a/src/test/java/com/github/davidmoten/rx2/internal/flowable/FlowableMergeInterleavedTest.java
+++ b/src/test/java/com/github/davidmoten/rx2/internal/flowable/FlowableMergeInterleavedTest.java
@@ -11,7 +11,7 @@ import io.reactivex.Flowable;
 public class FlowableMergeInterleavedTest {
 
     @Test
-//    @Ignore
+    @Ignore
     public void testInterleave() {
         Flowable<Integer> a = Flowable.just(1).repeat();
         Flowable<Integer> b = Flowable.just(2).repeat();

--- a/src/test/java/com/github/davidmoten/rx2/internal/flowable/FlowableMergeInterleavedTest.java
+++ b/src/test/java/com/github/davidmoten/rx2/internal/flowable/FlowableMergeInterleavedTest.java
@@ -7,7 +7,7 @@ import com.github.davidmoten.rx2.Flowables;
 
 import io.reactivex.Flowable;
 
-public class FlowableMergeInterleavedTest {
+public final class FlowableMergeInterleavedTest {
 
     @Test
     public void testInterleaveTwoInfiniteStreams() {

--- a/src/test/java/com/github/davidmoten/rx2/internal/flowable/FlowableMergeInterleavedTest.java
+++ b/src/test/java/com/github/davidmoten/rx2/internal/flowable/FlowableMergeInterleavedTest.java
@@ -1,5 +1,6 @@
 package com.github.davidmoten.rx2.internal.flowable;
 
+import org.junit.Ignore;
 import org.junit.Test;
 
 import com.github.davidmoten.rx2.Consumers;
@@ -10,6 +11,7 @@ import io.reactivex.Flowable;
 public class FlowableMergeInterleavedTest {
 
     @Test
+    @Ignore
     public void testInterleave() {
         Flowable<Integer> a = Flowable.just(1).repeat();
         Flowable<Integer> b = Flowable.just(2).repeat();

--- a/src/test/java/com/github/davidmoten/rx2/internal/flowable/FlowableMergeInterleavedTest.java
+++ b/src/test/java/com/github/davidmoten/rx2/internal/flowable/FlowableMergeInterleavedTest.java
@@ -11,7 +11,7 @@ import io.reactivex.Flowable;
 public class FlowableMergeInterleavedTest {
 
     @Test
-    @Ignore
+//    @Ignore
     public void testInterleave() {
         Flowable<Integer> a = Flowable.just(1).repeat();
         Flowable<Integer> b = Flowable.just(2).repeat();

--- a/src/test/java/com/github/davidmoten/rx2/internal/flowable/FlowableMergeInterleavedTest.java
+++ b/src/test/java/com/github/davidmoten/rx2/internal/flowable/FlowableMergeInterleavedTest.java
@@ -15,11 +15,86 @@ public class FlowableMergeInterleavedTest {
         Flowable<Integer> b = Flowable.just(2).repeat();
         Flowables.mergeInterleaved(Flowable.just(a, b), 2, 2, true) //
                 .doOnNext(Consumers.println()) //
-                .test(4)
-                .assertValues(1, 1, 2, 2)
-                .assertNotTerminated()
-                .requestMore(3) //
-                .assertValues(1, 1, 2, 2, 1, 1, 2);
+                .test(4) //
+                .assertValues(1, 1, 2, 2) //
+                .assertNotTerminated();
     }
+
+    @Test
+    public void testInterleaveTwoInfiniteStreamsRequestOne() {
+        Flowable<Integer> a = Flowable.just(1).repeat();
+        Flowable<Integer> b = Flowable.just(2).repeat();
+        Flowables.mergeInterleaved(Flowable.just(a, b), 2, 2, true) //
+                .doOnNext(Consumers.println()) //
+                .test(1) //
+                .assertValues(1) //
+                .assertNotTerminated();
+    }
+
+    @Test
+    public void testInterleaveTwoInfiniteStreamsRequestFive() {
+        Flowable<Integer> a = Flowable.just(1).repeat();
+        Flowable<Integer> b = Flowable.just(2).repeat();
+        Flowables.mergeInterleaved(Flowable.just(a, b), 2, 1, true) //
+                .doOnNext(Consumers.println()) //
+                .test(5) //
+                .assertValues(1, 2, 1, 2, 1) //
+                .assertNotTerminated();
+    }
+    
+    @Test
+    public void testInterleaveOneStream() {
+        Flowable<Integer> a = Flowable.just(1).repeat();
+        Flowables.mergeInterleaved(Flowable.just(a), 2, 2, true) //
+                .doOnNext(Consumers.println()) //
+                .test(5) //
+                .assertValues(1, 1, 1, 1, 1) //
+                .assertNotTerminated();
+    }
+    
+    @Test
+    public void testInterleaveInfiniteStreamWithFiniteStream() {
+        Flowable<Integer> a = Flowable.just(1).repeat();
+        Flowable<Integer> b = Flowable.just(2, 2);
+        Flowables.mergeInterleaved(Flowable.just(a, b), 2, 1, true) //
+                .doOnNext(Consumers.println()) //
+                .test(6) //
+                .assertValues(1, 2, 1, 2, 1, 1) //
+                .assertNotTerminated();
+    }
+    
+    @Test
+    public void testInterleaveInfiniteStreamWithNever() {
+        Flowable<Integer> a = Flowable.just(1).repeat();
+        Flowable<Integer> b = Flowable.never();
+        Flowables.mergeInterleaved(Flowable.just(a, b), 2, 1, true) //
+                .doOnNext(Consumers.println()) //
+                .test(3) //
+                .assertValues(1, 1, 1) //
+                .assertNotTerminated();
+    }
+    
+    @Test
+    public void testInterleaveInfiniteStreamWithNeverReversed() {
+        Flowable<Integer> a = Flowable.never();
+        Flowable<Integer> b = Flowable.just(1).repeat();
+        Flowables.mergeInterleaved(Flowable.just(a, b), 2, 1, true) //
+                .doOnNext(Consumers.println()) //
+                .test(3) //
+                .assertValues(1, 1, 1) //
+                .assertNotTerminated();
+    }
+    
+    @Test
+    public void testInterleaveTwoCompletingStreamsSameSize() {
+        Flowable<Integer> a = Flowable.just(1, 1, 1);
+        Flowable<Integer> b = Flowable.just(2, 2, 2);
+        Flowables.mergeInterleaved(Flowable.just(a, b), 2, 1, true) //
+                .doOnNext(Consumers.println()) //
+                .test() //
+                .assertValues(1, 2, 1, 2, 1, 2) //
+                .assertComplete();
+    }
+
 
 }

--- a/src/test/java/com/github/davidmoten/rx2/internal/flowable/FlowableMergeInterleavedTest.java
+++ b/src/test/java/com/github/davidmoten/rx2/internal/flowable/FlowableMergeInterleavedTest.java
@@ -1,6 +1,7 @@
 package com.github.davidmoten.rx2.internal.flowable;
 
-import org.junit.Ignore;
+import java.util.concurrent.TimeUnit;
+
 import org.junit.Test;
 
 import com.github.davidmoten.rx2.Consumers;
@@ -152,12 +153,12 @@ public final class FlowableMergeInterleavedTest {
     }
 
     @Test
-    @Ignore
     public void testInterleaveAsync() {
         Flowable<Integer> a = Flowable.just(1).repeat(100).subscribeOn(Schedulers.io());
         Flowable<Integer> b = Flowable.just(2).repeat(100);
         Flowables.mergeInterleaved(Flowable.just(a, b), 2, 2, true) //
                 .test() //
+                .awaitDone(10, TimeUnit.SECONDS) //
                 .assertValueCount(200) //
                 .assertComplete();
     }

--- a/src/test/java/com/github/davidmoten/rx2/internal/flowable/FlowableMergeInterleavedTest.java
+++ b/src/test/java/com/github/davidmoten/rx2/internal/flowable/FlowableMergeInterleavedTest.java
@@ -9,6 +9,7 @@ import com.github.davidmoten.rx2.Flowables;
 
 import io.reactivex.Flowable;
 import io.reactivex.schedulers.Schedulers;
+import io.reactivex.subscribers.TestSubscriber;
 
 public final class FlowableMergeInterleavedTest {
 
@@ -161,6 +162,19 @@ public final class FlowableMergeInterleavedTest {
                 .awaitDone(10, TimeUnit.SECONDS) //
                 .assertValueCount(200) //
                 .assertComplete();
+    }
+
+    @Test
+    public void testInterleaveCancel() {
+        Flowable<Integer> a = Flowable.just(1).repeat();
+        Flowable<Integer> b = Flowable.just(2).repeat();
+        TestSubscriber<Integer> ts = Flowables.mergeInterleaved(Flowable.just(a, b), 2, 1, true) //
+                .test(3);
+        ts.assertValues(1, 2, 1);
+        ts.cancel();
+        ts.requestMore(100) //
+                .assertValueCount(3) //
+                .assertNotTerminated();
     }
 
 }

--- a/src/test/java/com/github/davidmoten/rx2/internal/flowable/FlowableMergeInterleavedTest.java
+++ b/src/test/java/com/github/davidmoten/rx2/internal/flowable/FlowableMergeInterleavedTest.java
@@ -1,0 +1,23 @@
+package com.github.davidmoten.rx2.internal.flowable;
+
+import org.junit.Ignore;
+import org.junit.Test;
+
+import com.github.davidmoten.rx2.Consumers;
+import com.github.davidmoten.rx2.Flowables;
+
+import io.reactivex.Flowable;
+
+public class FlowableMergeInterleavedTest {
+
+    @Test
+    @Ignore
+    public void testInterleave() {
+        Flowable<Integer> a = Flowable.just(1).repeat();
+        Flowable<Integer> b = Flowable.just(2).repeat();
+        Flowables.mergeInterleaved(Flowable.just(a, b), 2, 4) //
+                .doOnNext(Consumers.println()) //
+                .test(24);
+    }
+
+}

--- a/src/test/java/com/github/davidmoten/rx2/internal/flowable/FlowableMergeInterleavedTest.java
+++ b/src/test/java/com/github/davidmoten/rx2/internal/flowable/FlowableMergeInterleavedTest.java
@@ -10,8 +10,7 @@ import io.reactivex.Flowable;
 
 public class FlowableMergeInterleavedTest {
 
-    @Test
-    @Ignore
+    @Test(timeout = 3000)
     public void testInterleave() {
         Flowable<Integer> a = Flowable.just(1).repeat();
         Flowable<Integer> b = Flowable.just(2).repeat();

--- a/src/test/java/com/github/davidmoten/rx2/internal/flowable/FlowableMergeInterleavedTest.java
+++ b/src/test/java/com/github/davidmoten/rx2/internal/flowable/FlowableMergeInterleavedTest.java
@@ -3,11 +3,14 @@ package com.github.davidmoten.rx2.internal.flowable;
 import java.util.concurrent.TimeUnit;
 
 import org.junit.Test;
+import org.reactivestreams.Publisher;
 
 import com.github.davidmoten.rx2.Consumers;
 import com.github.davidmoten.rx2.Flowables;
+import com.github.davidmoten.rx2.flowable.Transformers;
 
 import io.reactivex.Flowable;
+import io.reactivex.functions.Function;
 import io.reactivex.schedulers.Schedulers;
 import io.reactivex.subscribers.TestSubscriber;
 
@@ -189,7 +192,7 @@ public final class FlowableMergeInterleavedTest {
 
     @Test
     public void testManySources() {
-        //one million sources
+        // one million sources
         int n = 1000000;
         Flowables.mergeInterleaved(Flowable.just(Flowable.just(1)).repeat(n)) //
                 .batchSize(2) //
@@ -198,5 +201,19 @@ public final class FlowableMergeInterleavedTest {
                 .count() //
                 .test() //
                 .assertValue((long) n);
+    }
+
+    @Test
+    public void testFlatMap() {
+        Flowable.range(1, 1000)
+                .compose(Transformers.flatMapInterleaved(new Function<Object, Publisher<? extends Object>>() {
+                    @Override
+                    public Publisher<? extends Object> apply(Object x) throws Exception {
+                        return Flowable.just(x);
+                    }
+                }, 3)) //
+                .count() //
+                .test() //
+                .assertValue(1000L);
     }
 }

--- a/src/test/java/com/github/davidmoten/util/RingBufferTest.java
+++ b/src/test/java/com/github/davidmoten/util/RingBufferTest.java
@@ -1,0 +1,85 @@
+package com.github.davidmoten.util;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.util.Iterator;
+
+import org.junit.Test;
+
+public class RingBufferTest {
+
+    @Test
+    public void testEmpty() {
+        RingBuffer<Integer> q = RingBuffer.create(3);
+        assertTrue(q.isEmpty());
+        assertEquals(0, q.size());
+    }
+
+    @Test
+    public void testPush() {
+        RingBuffer<Integer> q = RingBuffer.create(3);
+        q.add(1);
+        assertFalse(q.isEmpty());
+        assertEquals(1, q.size());
+        assertEquals(1, (int) q.poll());
+        assertTrue(q.isEmpty());
+    }
+
+    @Test
+    public void testPushTwo() {
+        RingBuffer<Integer> q = RingBuffer.create(3);
+        q.add(1);
+        q.add(2);
+        assertFalse(q.isEmpty());
+        assertEquals(2, q.size());
+        assertEquals(1, (int) q.poll());
+        assertEquals(2, (int) q.poll());
+        assertTrue(q.isEmpty());
+        q.add(3);
+        q.add(4);
+        assertEquals(3, (int) q.poll());
+        assertEquals(4, (int) q.poll());
+    }
+
+    @Test(expected = RuntimeException.class)
+    public void testPushThreeOverflows() {
+        RingBuffer<Integer> q = RingBuffer.create(2);
+        q.add(1);
+        q.add(2);
+        q.add(3);
+        assertFalse(q.isEmpty());
+        assertEquals(3, q.size());
+        assertEquals(1, (int) q.poll());
+        assertEquals(2, (int) q.poll());
+        assertEquals(3, (int) q.poll());
+    }
+
+    public void testPushThreeInSizeThree() {
+        RingBuffer<Integer> q = RingBuffer.create(3);
+        q.add(1);
+        q.add(2);
+        q.add(3);
+        assertFalse(q.isEmpty());
+        assertEquals(3, q.size());
+        assertEquals(1, (int) q.poll());
+        assertEquals(2, (int) q.poll());
+        assertEquals(3, (int) q.poll());
+    }
+
+    public void testPushThreeAndEnumerate() {
+        RingBuffer<Integer> q = RingBuffer.create(3);
+        q.add(1);
+        q.add(2);
+        q.add(3);
+        Iterator<Integer> en = q.iterator();
+        assertEquals(1, (int) en.next());
+        assertEquals(1, (int) q.poll());
+        assertEquals(2, (int) en.next());
+        assertEquals(2, (int) q.poll());
+        assertEquals(3, (int) en.next());
+        assertEquals(3, (int) q.poll());
+        assertFalse(en.hasNext());
+    }
+}


### PR DESCRIPTION
This PR adds a new operator `Flowables.mergeInterleaved`. 

When you use a `Flowable.merge` on synchronous sources the sources are completely consumed serially one by one. As a consequence if you want to merge two infinite sources synchronously then you only get the first source and the second source is never read.

`Flowables.mergeInterleaved` round-robins the requests to the window of current publishers (up to `maxConcurrent`) so that two or more infinite streams can be merged without resorting to apply asynchronicity via an asynchronous scheduler.

There is a sacrifice made in that the operator is much less performant than merging asynchronous streams because only one stream is requested from at a time.

Have also added `Transformers.flatMapInterleaved`.