### PR TITLE
Add insert and buffer(maxSize, timeout) operators

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,13 +114,17 @@ Maybe<String> o = Flowable
 
 [Transformers (Flowable)](https://davidmoten.github.io/rxjava2-extras/apidocs/com/github/davidmoten/rx2/flowable/Transformers.html)
 ---------------------------
+[`buffer`](#buffer) with size and timeout
+
 [`collectStats`](#collectstats)
 
 [`doOnEmpty`](#doonempty)
 
 [`collectWhile`](#collectwhile)
 
-[`flatMapInterleaved`](#flatmapinterleaved)
+[`flatMapInterleaved`](#mergeinterleaved)
+
+[`insert`](#insert)
 
 [`mapLast`](#maplast)
 
@@ -220,6 +224,21 @@ SchedulerHelper
 
 # Documentation
 
+buffer
+--------------------------
+To buffer on maximum size and time since last source emission:
+
+```java
+flowable.compose(
+  Transformers.buffer(maxSize, 10, TimeUnit.SECONDS));
+```
+ You can also make the timeout dependent on the last emission:
+
+```java
+flowable.compose(
+  Transformers.buffer(maxSize, x -> timeout(x), TimeUnit.SECONDS));
+```
+
 collectStats
 ---------------------------
 Accumulate statistics, emitting the accumulated results with each item.
@@ -311,6 +330,33 @@ mostPopularMovies()
 
 A bit more detail about `fetchPagesByRequest`:
 * if the `fetch` function returns a `Flowable` that delivers fewer than the requested number of items then the overall stream completes.
+
+insert
+-------------------------
+Inserts zero or one items into a stream if the given Maybe succeeds before the next source emission.
+
+Example:
+```java
+Flowable
+  .interval(1, TimeUnit.SECONDS)
+  .compose(Transformers.insert(
+     Maybe.just(-1L).delay(500, TimeUnit.MILLISECONDS))) 
+  .forEach(System.out::println);
+```
+produces (with 500ms intervals between every emission):
+```
+0
+-1
+1
+-1
+2
+-1
+3
+-1
+4
+-1
+...
+```
     
 mapLast
 -------------------------

--- a/pom.xml
+++ b/pom.xml
@@ -185,7 +185,7 @@
         <plugins>
             <plugin>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.5.1</version>
+                <version>3.8.0</version>
                 <configuration>
                     <source>${maven.compiler.target}</source>
                     <target>${maven.compiler.target}</target>

--- a/src/main/java/com/github/davidmoten/rx2/internal/flowable/FlowableInsertMaybe.java
+++ b/src/main/java/com/github/davidmoten/rx2/internal/flowable/FlowableInsertMaybe.java
@@ -1,0 +1,298 @@
+package com.github.davidmoten.rx2.internal.flowable;
+
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.atomic.AtomicReference;
+
+import org.reactivestreams.Subscriber;
+import org.reactivestreams.Subscription;
+
+import com.github.davidmoten.guavamini.Preconditions;
+
+import io.reactivex.Flowable;
+import io.reactivex.FlowableSubscriber;
+import io.reactivex.Maybe;
+import io.reactivex.MaybeObserver;
+import io.reactivex.disposables.Disposable;
+import io.reactivex.exceptions.Exceptions;
+import io.reactivex.functions.Function;
+import io.reactivex.internal.disposables.DisposableHelper;
+import io.reactivex.internal.fuseable.SimplePlainQueue;
+import io.reactivex.internal.queue.MpscLinkedQueue;
+import io.reactivex.internal.subscriptions.SubscriptionHelper;
+import io.reactivex.internal.util.BackpressureHelper;
+import io.reactivex.plugins.RxJavaPlugins;
+
+public final class FlowableInsertMaybe<T> extends Flowable<T> {
+
+    private final Flowable<T> source;
+    private final Function<? super T, ? extends Maybe<? extends T>> valueToInsert;
+
+    public FlowableInsertMaybe(Flowable<T> source, Function<? super T, ? extends Maybe<? extends T>> valueToInsert) {
+        Preconditions.checkNotNull(valueToInsert, "valueToInsert cannot be null");
+        this.source = source;
+        this.valueToInsert = valueToInsert;
+    }
+
+    @Override
+    protected void subscribeActual(Subscriber<? super T> downstream) {
+        source.subscribe(new InsertSubscriber<T>(downstream, valueToInsert));
+    }
+
+    static final class InsertSubscriber<T> extends AtomicInteger implements FlowableSubscriber<T>, Subscription {
+
+        private static final long serialVersionUID = -15415234346097063L;
+
+        private final Subscriber<? super T> downstream;
+        private final Function<? super T, ? extends Maybe<? extends T>> valueToInsert;
+        private final SimplePlainQueue<T> queue;
+        private final AtomicLong requested;
+        private final AtomicLong inserted;
+
+        // define as type Object so can set with a non-null sentinel object that does
+        // not gather a stacktrace. A further refinement would be to use just one
+        // AtomicReference for `error` and `done` (leaving it for now)
+        private final AtomicReference<Object> error;
+        private final AtomicReference<Disposable> valueToInsertObserver;
+
+        private Subscription upstream;
+        private volatile boolean done;
+        private volatile boolean cancelled;
+
+        // used to prevent emission of events after a terminal event
+        // does not need to be volatile
+        private boolean finished;
+
+        InsertSubscriber(Subscriber<? super T> downstream,
+                Function<? super T, ? extends Maybe<? extends T>> valueToInsert) {
+            this.downstream = downstream;
+            this.valueToInsert = valueToInsert;
+            this.queue = new MpscLinkedQueue<T>();
+            this.requested = new AtomicLong();
+            this.inserted = new AtomicLong();
+            this.error = new AtomicReference<Object>();
+            this.valueToInsertObserver = new AtomicReference<Disposable>();
+        }
+
+        @Override
+        public void onSubscribe(Subscription upstream) {
+            if (SubscriptionHelper.validate(this.upstream, upstream)) {
+                this.upstream = upstream;
+                downstream.onSubscribe(this);
+            }
+        }
+
+        @Override
+        public void onNext(T t) {
+            if (finished) {
+                return;
+            }
+            queue.offer(t);
+            Maybe<? extends T> maybe;
+            try {
+                maybe = valueToInsert.apply(t);
+            } catch (Throwable e) {
+                Exceptions.throwIfFatal(e);
+                // we cancel upstream ourselves because the
+                // error did not originate from source
+                upstream.cancel();
+                onError(e);
+                return;
+            }
+            ValueToInsertObserver<T> o = new ValueToInsertObserver<T>(this);
+            if (DisposableHelper.set(valueToInsertObserver, o)) {
+                // note that at this point we have to cover o being disposed
+                // from another thread so the Observer class needs
+                // to handle dispose being called before/during onSubscribe
+                maybe.subscribe(o);
+            }
+            drain();
+        }
+
+        @Override
+        public void onError(Throwable e) {
+            if (finished) {
+                RxJavaPlugins.onError(e);
+                return;
+            }
+            finished = true;
+            if (error.compareAndSet(null, e)) {
+                DisposableHelper.dispose(valueToInsertObserver);
+                done = true;
+                drain();
+            } else {
+                RxJavaPlugins.onError(e);
+            }
+        }
+
+        @Override
+        public void onComplete() {
+            if (finished) {
+                return;
+            }
+            finished = true;
+            DisposableHelper.dispose(valueToInsertObserver);
+            done = true;
+            drain();
+        }
+
+        private void drain() {
+            if (getAndIncrement() != 0) {
+                return;
+            }
+            // note that this drain loop does not shortcut errors
+            int missed = 1;
+            while (true) {
+                long r = requested.get();
+                long e = 0;
+                while (e != r) {
+                    if (cancelled) {
+                        DisposableHelper.dispose(valueToInsertObserver);
+                        queue.clear();
+                        return;
+                    }
+                    // must read `done` before polling queue
+                    boolean d = done;
+                    T t = queue.poll();
+                    if (t == null) {
+                        if (d) {
+                            Object err = error.get();
+                            if (err != null) {
+                                // clear the exception so can be gc'd
+                                // `this` is not a real error, it just prevents
+                                // it getting set again in a race because the other
+                                // setters which use CAS assume initial value of null
+                                error.set(this);
+                                DisposableHelper.dispose(valueToInsertObserver);
+                                downstream.onError((Throwable) err);
+                            } else {
+                                // don't need to dispose valueToInsertObserver because already done in
+                                // onComplete
+                                downstream.onComplete();
+                            }
+                            return;
+                        } else {
+                            // nothing to emit and not done
+                            break;
+                        }
+                    } else {
+                        downstream.onNext(t);
+                        e++;
+                    }
+                }
+                if (e != 0L && r != Long.MAX_VALUE) {
+                    requested.addAndGet(-e);
+                }
+                missed = addAndGet(-missed);
+                if (missed == 0) {
+                    return;
+                }
+            }
+        }
+
+        @Override
+        public void request(long n) {
+            if (SubscriptionHelper.validate(n)) {
+                BackpressureHelper.add(requested, n);
+                // modify request to upstream to account for inserted values
+                // use a CAS loop because request can be called from any thread
+                while (true) {
+                    long ins = inserted.get();
+                    long d = Math.min(ins, n);
+                    if (inserted.compareAndSet(ins, ins - d)) {
+                        if (n - d > 0) {
+                            upstream.request(n - d);
+                        }
+                        break;
+                    }
+                }
+                drain();
+            }
+        }
+
+        @Override
+        public void cancel() {
+            if (!cancelled) {
+                cancelled = true;
+                upstream.cancel();
+                DisposableHelper.dispose(valueToInsertObserver);
+                if (getAndIncrement() == 0) {
+                    // use the same access control to queue as drain method
+                    // because `clear` just calls `queue.poll()` repeatedly till nothing left on the
+                    // queue (ignoring the dequeued items).
+                    //
+                    // this is best endeavours, there still exists a race with onNext and drain
+                    // where items could be left on the queue after cancel
+                    queue.clear();
+                }
+            }
+        }
+
+        void insert(T t) {
+            inserted.incrementAndGet();
+            queue.offer(t);
+            drain();
+        }
+
+        void insertError(Throwable e) {
+            if (error.compareAndSet(null, e)) {
+                upstream.cancel();
+                DisposableHelper.dispose(valueToInsertObserver);
+                done = true;
+                drain();
+            } else {
+                RxJavaPlugins.onError(e);
+            }
+        }
+
+    }
+
+    static final class ValueToInsertObserver<T> extends AtomicReference<Disposable>
+            implements MaybeObserver<T>, Disposable {
+
+        private static final long serialVersionUID = 41384726414575403L;
+
+        private final InsertSubscriber<T> downstream;
+
+        ValueToInsertObserver(InsertSubscriber<T> downstream) {
+            this.downstream = downstream;
+        }
+
+        @Override
+        public void onSubscribe(Disposable upstream) {
+            // an AtomicReference is used to hold the upstream Disposable
+            // because this Observer can be disposed before onSubscribe
+            // is called (contrary to the normal contract).
+            DisposableHelper.setOnce(this, upstream);
+        }
+
+        @Override
+        public void onSuccess(T t) {
+            lazySet(DisposableHelper.DISPOSED);
+            downstream.insert(t);
+        }
+
+        @Override
+        public void onError(Throwable e) {
+            lazySet(DisposableHelper.DISPOSED);
+            downstream.insertError(e);
+        }
+
+        @Override
+        public void onComplete() {
+            lazySet(DisposableHelper.DISPOSED);
+            // don't do anything else because no value to insert was reported
+        }
+
+        @Override
+        public void dispose() {
+            DisposableHelper.dispose(this);
+        }
+
+        @Override
+        public boolean isDisposed() {
+            return get() == DisposableHelper.DISPOSED;
+        }
+
+    }
+}

--- a/src/main/java/com/github/davidmoten/rx2/internal/flowable/FlowableInsertTimeout.java
+++ b/src/main/java/com/github/davidmoten/rx2/internal/flowable/FlowableInsertTimeout.java
@@ -1,0 +1,297 @@
+package com.github.davidmoten.rx2.internal.flowable;
+
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.atomic.AtomicReference;
+
+import org.reactivestreams.Subscriber;
+import org.reactivestreams.Subscription;
+
+import com.github.davidmoten.guavamini.Preconditions;
+
+import io.reactivex.Flowable;
+import io.reactivex.FlowableSubscriber;
+import io.reactivex.Scheduler;
+import io.reactivex.Scheduler.Worker;
+import io.reactivex.disposables.Disposable;
+import io.reactivex.exceptions.Exceptions;
+import io.reactivex.functions.Function;
+import io.reactivex.internal.disposables.DisposableHelper;
+import io.reactivex.internal.fuseable.SimplePlainQueue;
+import io.reactivex.internal.queue.MpscLinkedQueue;
+import io.reactivex.internal.subscriptions.SubscriptionHelper;
+import io.reactivex.internal.util.BackpressureHelper;
+import io.reactivex.plugins.RxJavaPlugins;
+
+public final class FlowableInsertTimeout<T> extends Flowable<T> {
+
+    private final Flowable<T> source;
+    private final Function<? super T, ? extends Long> timeout;
+    private final TimeUnit unit;
+    private final Function<? super T, ? extends T> value;
+    private final Scheduler scheduler;
+
+    public FlowableInsertTimeout(Flowable<T> source, Function<? super T, ? extends Long> timeout, TimeUnit unit,
+            Function<? super T, ? extends T> value, Scheduler scheduler) {
+        Preconditions.checkNotNull(timeout, "timeout cannot be null");
+        Preconditions.checkNotNull(unit, "unit cannot be null");
+        Preconditions.checkNotNull(value, "value cannot be null");
+        Preconditions.checkNotNull(scheduler, "scheduler cannot be null");
+        this.source = source;
+        this.timeout = timeout;
+        this.unit = unit;
+        this.value = value;
+        this.scheduler = scheduler;
+    }
+
+    @Override
+    protected void subscribeActual(Subscriber<? super T> downstream) {
+        source.subscribe(new InsertTimeoutSubscriber<T>(downstream, timeout, unit, value, scheduler));
+    }
+
+    static final class InsertTimeoutSubscriber<T> extends AtomicInteger implements FlowableSubscriber<T>, Subscription {
+
+        private static final long serialVersionUID = 1812803226317104954L;
+
+        private static final Object TERMINATED = new Object();
+
+        private final Subscriber<? super T> downstream;
+        private final Function<? super T, ? extends Long> timeout;
+        private final TimeUnit unit;
+        private final Function<? super T, ? extends T> value;
+
+        private final SimplePlainQueue<T> queue;
+        private final AtomicLong requested;
+        private final AtomicLong inserted;
+
+        // set either with null (not terminated), Throwable (error), or
+        // TERMINATED (completion). TERMINATED is also used to replace an 
+        // error after it is reported downstream so that the local copy of the 
+        // error can be gc'd
+        private final AtomicReference<Object> terminated;
+        private final AtomicReference<Disposable> scheduled;
+
+        private Subscription upstream;
+        private volatile boolean cancelled;
+
+        // used to prevent emission of events after a terminal event
+        // does not need to be volatile
+        private boolean finished;
+
+        private final Worker worker;
+
+        InsertTimeoutSubscriber(Subscriber<? super T> downstream, Function<? super T, ? extends Long> timeout,
+                TimeUnit unit, Function<? super T, ? extends T> value, Scheduler scheduler) {
+            this.downstream = downstream;
+            this.timeout = timeout;
+            this.unit = unit;
+            this.value = value;
+            this.queue = new MpscLinkedQueue<T>();
+            this.requested = new AtomicLong();
+            this.inserted = new AtomicLong();
+            this.terminated = new AtomicReference<Object>();
+            this.scheduled = new AtomicReference<Disposable>();
+            this.worker = scheduler.createWorker();
+        }
+
+        @Override
+        public void onSubscribe(Subscription upstream) {
+            if (SubscriptionHelper.validate(this.upstream, upstream)) {
+                this.upstream = upstream;
+                downstream.onSubscribe(this);
+            }
+        }
+
+        @Override
+        public void onNext(final T t) {
+            if (finished) {
+                return;
+            }
+            queue.offer(t);
+            final long waitTime;
+            try {
+                waitTime = timeout.apply(t);
+            } catch (Throwable e) {
+                Exceptions.throwIfFatal(e);
+                // we cancel upstream ourselves because the
+                // error did not originate from source
+                upstream.cancel();
+                onError(e);
+                return;
+            }
+            TimeoutAction<T> action = new TimeoutAction<T>(this, t);
+            Disposable d = worker.schedule(action, waitTime, unit);
+            DisposableHelper.set(scheduled, d);
+            drain();
+        }
+
+        @Override
+        public void onError(Throwable e) {
+            if (finished) {
+                RxJavaPlugins.onError(e);
+                return;
+            }
+            finished = true;
+            if (terminated.compareAndSet(null, e)) {
+                dispose();
+                drain();
+            } else {
+                RxJavaPlugins.onError(e);
+            }
+        }
+
+        @Override
+        public void onComplete() {
+            if (finished) {
+                return;
+            }
+            finished = true;
+            if (terminated.compareAndSet(null, TERMINATED)) {
+                dispose();
+                drain();
+            }
+        }
+
+        private void drain() {
+            if (getAndIncrement() != 0) {
+                return;
+            }
+            // note that this drain loop does not shortcut errors
+            int missed = 1;
+            while (true) {
+                long r = requested.get();
+                long e = 0;
+                while (e != r) {
+                    if (cancelled) {
+                        dispose();
+                        queue.clear();
+                        return;
+                    }
+                    Object d = terminated.get();
+                    T t = queue.poll();
+                    if (t == null) {
+                        if (d != null) {
+                            // d will be either TERMINATED or a Throwable
+                            if (d == TERMINATED) {
+                                // don't need to dispose scheduled because already done in
+                                // onComplete
+                                downstream.onComplete();
+                            } else {
+                                // clear the exception so can be gc'd
+                                // setting the value to TERMINATED just prevents it getting set again in a race
+                                // because the other setters which use CAS assume initial value of null
+                                terminated.set(TERMINATED);
+                                dispose();
+                                downstream.onError((Throwable) d);
+                            }
+                            return;
+                        } else {
+                            // nothing to emit and not done
+                            break;
+                        }
+                    } else {
+                        downstream.onNext(t);
+                        e++;
+                    }
+                }
+                if (e != 0L && r != Long.MAX_VALUE) {
+                    requested.addAndGet(-e);
+                }
+                missed = addAndGet(-missed);
+                if (missed == 0) {
+                    return;
+                }
+            }
+        }
+
+        @Override
+        public void request(long n) {
+            if (SubscriptionHelper.validate(n)) {
+                BackpressureHelper.add(requested, n);
+                // modify request to upstream to account for inserted values
+                // use a CAS loop because request can be called from any thread
+                while (true) {
+                    long ins = inserted.get();
+                    long d = Math.min(ins, n);
+                    if (inserted.compareAndSet(ins, ins - d)) {
+                        if (n - d > 0) {
+                            upstream.request(n - d);
+                        }
+                        break;
+                    }
+                }
+                drain();
+            }
+        }
+
+        @Override
+        public void cancel() {
+            if (!cancelled) {
+                cancelled = true;
+                upstream.cancel();
+                dispose();
+                if (getAndIncrement() == 0) {
+                    // use the same access control to queue as drain method
+                    // because `clear` just calls `queue.poll()` repeatedly till nothing left on the
+                    // queue (ignoring the dequeued items).
+                    //
+                    // this is best endeavours, there still exists a race with onNext and drain
+                    // where items could be left on the queue after cancel
+                    queue.clear();
+                }
+            }
+        }
+
+        private void dispose() {
+            DisposableHelper.dispose(scheduled);
+            worker.dispose();
+        }
+        
+        void insert(T t) {
+            inserted.incrementAndGet();
+            queue.offer(t);
+            drain();
+        }
+
+        void insertError(Throwable e) {
+            if (terminated.compareAndSet(null, e)) {
+                upstream.cancel();
+                dispose();
+                drain();
+            } else {
+                RxJavaPlugins.onError(e);
+            }
+        }
+
+        T calculateValueToInsert(T t) throws Exception {
+            return value.apply(t);
+        }
+
+    }
+
+    private static final class TimeoutAction<T> implements Runnable {
+
+        private final InsertTimeoutSubscriber<T> subscriber;
+        private final T t;
+
+        TimeoutAction(InsertTimeoutSubscriber<T> subscriber, T t) {
+            this.subscriber = subscriber;
+            this.t = t;
+        }
+
+        @Override
+        public void run() {
+            final T v;
+            try {
+                v = subscriber.calculateValueToInsert(t);
+            } catch (Throwable e) {
+                subscriber.insertError(e);
+                return;
+            }
+            subscriber.insert(v);
+        }
+
+    }
+
+}

--- a/src/test/java/com/github/davidmoten/rx2/flowable/TransformersTest.java
+++ b/src/test/java/com/github/davidmoten/rx2/flowable/TransformersTest.java
@@ -3,14 +3,28 @@ package com.github.davidmoten.rx2.flowable;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
-import org.junit.Test;
+import java.io.IOException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
 
+import org.junit.Test;
+import org.reactivestreams.Subscriber;
+import org.reactivestreams.Subscription;
+
+import com.github.davidmoten.guavamini.Lists;
 import com.github.davidmoten.junit.Asserts;
+import com.github.davidmoten.rx2.Consumers;
 import com.github.davidmoten.rx2.Functions;
 import com.github.davidmoten.rx2.Statistics;
+import com.github.davidmoten.rx2.exceptions.ThrowingException;
 import com.github.davidmoten.rx2.util.Pair;
 
 import io.reactivex.Flowable;
+import io.reactivex.Maybe;
+import io.reactivex.functions.Function;
+import io.reactivex.schedulers.Schedulers;
+import io.reactivex.schedulers.TestScheduler;
+import io.reactivex.subscribers.TestSubscriber;
 
 public class TransformersTest {
 
@@ -47,7 +61,7 @@ public class TransformersTest {
         assertEquals(35.0, s.sum(), 0.0001);
         assertEquals(8.75, s.mean(), 0.00001);
         assertEquals(7.258615570478987, s.sd(), 0.00001);
-        assertEquals(1+16+100+400, s.sumSquares(), 0.0001);
+        assertEquals(1 + 16 + 100 + 400, s.sumSquares(), 0.0001);
     }
 
     @Test
@@ -88,4 +102,229 @@ public class TransformersTest {
         assertEquals("Statistics [count=2, sum=3.0, sumSquares=5.0, mean=1.5, sd=0.5]", s.toString());
     }
 
+    @Test
+    public void testInsert() {
+        Flowable.just(1, 2) //
+                .compose(Transformers.insert(Maybe.just(3))) //
+                .test() //
+                .assertValues(1, 3, 2, 3) //
+                .assertComplete();
+    }
+
+    @Test
+    public void testInsertWithDelays() {
+        TestScheduler s = new TestScheduler();
+        TestSubscriber<Integer> ts = //
+                Flowable.just(1).delay(1, TimeUnit.SECONDS, s) //
+                        .concatWith(Flowable.just(2).delay(3, TimeUnit.SECONDS, s)) //
+                        .compose(Transformers.insert(Maybe.just(3).delay(2, TimeUnit.SECONDS, s))) //
+                        .test();
+        ts.assertNoValues();
+        s.advanceTimeBy(1, TimeUnit.SECONDS);
+        ts.assertValues(1);
+        s.advanceTimeBy(2, TimeUnit.SECONDS);
+        ts.assertValues(1, 3);
+        s.advanceTimeBy(1, TimeUnit.SECONDS);
+        ts.assertValues(1, 3, 2);
+        ts.assertComplete();
+    }
+
+    @Test
+    public void testInsertBackpressure() {
+        Flowable.just(1, 2) //
+                .compose(Transformers.insert(Maybe.just(3))) //
+                .test(0) //
+                .assertNoValues() //
+                .requestMore(1) //
+                .assertValues(1) //
+                .requestMore(3) //
+                .assertValues(1, 3, 2, 3) //
+                .requestMore(1) //
+                .assertValueCount(4) //
+                .assertComplete();
+    }
+
+    @Test
+    public void testInsertSourceError() {
+        Flowable.<Integer>error(new IOException("boo")) //
+                .compose(Transformers.insert(Maybe.just(3))) //
+                .test() //
+                .assertNoValues() //
+                .assertErrorMessage("boo");
+    }
+
+    @Test
+    public void testInsertError() {
+        Flowable.just(1, 2) //
+                .compose(Transformers.insert(Maybe.error(new IOException("boo")))) //
+                .test() //
+                .assertValue(1) //
+                .assertErrorMessage("boo");
+    }
+
+    @Test
+    public void testInsertCancel() {
+        TestSubscriber<Integer> ts = Flowable.just(1, 2) //
+                .compose(Transformers.insert(Maybe.just(3))) //
+                .test(0) //
+                .assertNoValues() //
+                .requestMore(1) //
+                .assertValues(1);
+        ts.cancel();
+        ts.requestMore(100) //
+                .assertValues(1) //
+                .assertNotTerminated();
+    }
+    
+    @Test
+    public void testInsertMapperError() {
+        Flowable.just(1, 2) //
+                .compose(Transformers.insert(Functions.<Integer, Maybe<Integer>>throwing())) //
+                .test() //
+                .assertValue(1) //
+                .assertError(ThrowingException.class);
+    }
+    
+    @Test
+    public void testInsertNothing() {
+        Flowable.just(1, 2, 3) //
+                .compose(Transformers.insert(Functions.constant(Maybe.<Integer>empty()))) //
+                .test() //
+                .assertValues(1, 2, 3) //
+                .assertComplete();
+    }
+    
+    @Test
+    public void testInsertNoOnNextOrCompleteEventsProcessedAfterMapperError() {
+        assertEquals(1, countMapperCalls(true));
+    }
+    
+    @Test
+    public void testInsertNoOnNextOrErrorEventsProcessedAfterMapperError() {
+        assertEquals(1, countMapperCalls(false));
+    }
+
+    private int countMapperCalls(final boolean complete) {
+        final AtomicInteger count = new AtomicInteger();
+        final Function<Integer, Maybe<Integer>> mapper = new Function<Integer, Maybe<Integer>>() {
+            @Override
+            public Maybe<Integer> apply(Integer t) throws Exception {
+                count.incrementAndGet();
+                throw new ThrowingException();
+            }
+        };
+        // construct a Flowable that ignores cancellation (and always expects a
+        // Long.MAX_VALUE request)
+        new Flowable<Integer>() {
+
+            @Override
+            protected void subscribeActual(final Subscriber<? super Integer> s) {
+                s.onSubscribe(new Subscription() {
+
+                    @Override
+                    public void request(long n) {
+                        s.onNext(1);
+                        s.onNext(2);
+                        if (complete) {
+                            s.onComplete();
+                        } else {
+                            s.onError(new IOException("boo"));
+                        }
+                    }
+
+                    @Override
+                    public void cancel() {
+                        // ignore
+                    }
+                });
+            }
+        } //
+                .compose(Transformers.insert(mapper)) //
+                .test() //
+                .assertValue(1) //
+                .assertError(ThrowingException.class);
+        return count.get();
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    public void testBufferMaxCountAndTimeout() {
+        int maxSize = 3;
+        Flowable.just(1, 2, 3) //
+                .compose(Transformers.<Integer>buffer(maxSize, 0, TimeUnit.SECONDS, Schedulers.trampoline())).test() //
+                .assertValues(Lists.newArrayList(1), Lists.newArrayList(2), Lists.newArrayList(3)) //
+                .assertComplete();
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    public void testBufferMaxCountAndTimeoutAsyncCountWins() {
+        int maxSize = 3;
+        Flowable.just(1, 2, 3, 4) //
+                .concatWith(Flowable.just(5).delay(500, TimeUnit.MILLISECONDS)) //
+                .compose(Transformers.<Integer>buffer(maxSize, 100, TimeUnit.MILLISECONDS)) //
+                .test() //
+                .awaitDone(10, TimeUnit.SECONDS) //
+                .assertValues(Lists.newArrayList(1, 2, 3), Lists.newArrayList(4), Lists.newArrayList(5)) //
+                .assertComplete();
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    public void testBufferMaxCountAndTimeoutAsyncTimeoutWins() {
+        int maxSize = 3;
+        Flowable.just(1, 2) //
+        .timeout(1, TimeUnit.SECONDS) //
+                .concatWith(Flowable.just(3).delay(500, TimeUnit.MILLISECONDS)) //
+                .compose(Transformers.<Integer>buffer(maxSize, 100, TimeUnit.MILLISECONDS)) //
+                .test() //
+                .awaitDone(10, TimeUnit.SECONDS) //
+                .assertValues(Lists.newArrayList(1, 2), Lists.newArrayList(3)) //
+                .assertComplete();
+    }
+    
+    @Test
+    public void testBufferTimeoutSourceError() {
+        Flowable.<Integer>error(new ThrowingException()) //
+           .compose(Transformers.<Integer>buffer(3, 100, TimeUnit.MILLISECONDS)) //
+           .test() //
+           .awaitDone(10, TimeUnit.SECONDS) //
+           .assertNoValues() //
+           .assertError(ThrowingException.class);
+    }
+    
+    @Test
+    public void testInsertTimeoutValueError() {
+        Flowable.just(1).concatWith(Flowable.<Integer>never()) //
+                .compose(Transformers.<Integer>insert( //
+                        Functions.constant(7L), //
+                        TimeUnit.MILLISECONDS, //
+                        Functions.<Integer, Integer>throwing())) //
+                .test() //
+                .awaitDone(10, TimeUnit.SECONDS) //
+                .assertValues(1) //
+                .assertError(ThrowingException.class);
+    }
+    
+    @Test
+    public void testInsertTimeoutCancel() {
+        Flowable.just(1, 2) //
+                .compose(Transformers.<Integer>insert( //
+                        Functions.constant(7L), //
+                        TimeUnit.SECONDS, //
+                        Functions.<Integer, Integer>throwing())) //
+                .take(1) //
+                .test() //
+                .awaitDone(10, TimeUnit.SECONDS) //
+                .assertValue(1);
+    }
+    
+    public static void main(String[] args) {
+        Flowable.interval(1, TimeUnit.SECONDS) //
+            .compose(Transformers.insert(Maybe.just(-1L).delay(500, TimeUnit.MILLISECONDS))) //
+            .doOnNext(Consumers.println()) //
+            .count() //
+            .blockingGet();
+    }
+    
 }

--- a/src/test/java/com/github/davidmoten/rx2/internal/flowable/FlowableMaxRequestTest.java
+++ b/src/test/java/com/github/davidmoten/rx2/internal/flowable/FlowableMaxRequestTest.java
@@ -124,9 +124,9 @@ public class FlowableMaxRequestTest {
     @Test
     public void checkCancel() {
         List<Long> requests = new CopyOnWriteArrayList<Long>();
-        TestSubscriber<Object> ts = Flowable.range(1, 10) //
+        TestSubscriber<Integer> ts = Flowable.range(1, 10) //
                 .doOnRequest(Consumers.addLongTo(requests)) //
-                .compose(Transformers.maxRequest(3)) //
+                .compose(Transformers.<Integer>maxRequest(3)) //
                 .test(4).assertValues(1, 2, 3, 4); //
         ts.cancel();
         ts.requestMore(3);


### PR DESCRIPTION
As discussed in https://github.com/ReactiveX/RxJava/issues/6417, an operator has been requested similar to `buffer(size)` which buffers emissions into lists of up to `size` elements but also emits the current buffer once there has been no emission for a certain time.

Rather than making a new complex custom operator with this functionality based on the [`collectWhile`](https://github.com/davidmoten/rxjava2-extras#collectwhile) operator I've instead chosen to reduce complexity by separating out the functionality of emitting something extra (without cancelling the original stream) when the stream has not emitted anything for a time into a new operator called `insert`. Moreover the "emitted anything for a time" criterion can be expressed more generically as a `Maybe`.

An example of `insert` (using `FlowableInsertMaybe`):

```java
Flowable<Integer> flowable = ...;
Flowable<Integer> flowable2 = flowable.compose(
       Transformers.insert(x -> Maybe.just(-1)).delay(1, TimeUnit.SECONDS));
```
Whenever the time since the last emission grows to a second, the item `-1` will be emitted (followed by the rest of the stream once it arrives). 

Another example using `FlowableInsertTimeout` under the covers:
```java
Flowable<Integer> flowable = ...;
Flowable<Integer> flowable2 = flowable.compose(
       Transformers.insert(x -> 1, TimeUnit.SECONDS, x -> -1);
```

A source stream can then be mapped to a stream of `Optional` (I use `MyOptional` because `java.util.Optional` does not exist in Java 6) then passed through `insert` (which inserts items of `Optional.empty()`)  then to `collectWhile` (where you can specify the `add` function and the `condition` so that inserted items are ignored in the emitted lists and a list is emitted whenever the max size is reached or the last item is an inserted item).

The end result is an operator `Transformers.buffer(int maxSize, long duration, TimeUnit unit)` that meets the requirements of https://github.com/ReactiveX/RxJava/issues/6417.

Here's example usage of new `buffer` method (from a unit test):

```java
int maxSize = 5;
Flowable
   .just(1, 2) 
   .concatWith(Flowable.just(3).delay(500, TimeUnit.MILLISECONDS)) 
   .compose(Transformers.<Integer>buffer(maxSize, 100, TimeUnit.MILLISECONDS)) 
   .test() 
   .awaitDone(10, TimeUnit.SECONDS) 
   .assertValues(Lists.newArrayList(1, 2), Lists.newArrayList(3)) 
   .assertComplete();
```
Note also that an overload of the `buffer` method has been added to make the timeout dependent on the last emission if desired.

cc @lalithsuresh



