### PR TITLE
Avoid requesting the default schedulers if a scheduler is specified explicitly.

### DIFF
--- a/src/main/java/com/github/davidmoten/rx2/RetryWhen.java
+++ b/src/main/java/com/github/davidmoten/rx2/RetryWhen.java
@@ -191,7 +191,7 @@ public final class RetryWhen {
 
         private Flowable<Long> delays = Flowable.just(0L).repeat();
         private Optional<Integer> maxRetries = Optional.absent();
-        private Optional<Scheduler> scheduler = Optional.of(Schedulers.computation());
+        private Optional<Scheduler> scheduler = Optional.absent();
         private Consumer<? super ErrorAndDuration> action = Consumers.doNothing();
 
         private Builder() {
@@ -298,7 +298,8 @@ public final class RetryWhen {
             if (maxRetries.isPresent()) {
                 delays = delays.take(maxRetries.get());
             }
-            return notificationHandler(delays, scheduler.get(), action, retryExceptions, failExceptions,
+            Scheduler s = scheduler.isPresent() ? scheduler.get() : Schedulers.computation();
+            return notificationHandler(delays, s, action, retryExceptions, failExceptions,
                     exceptionPredicate);
         }
 

--- a/src/main/java/com/github/davidmoten/rx2/buffertofile/Options.java
+++ b/src/main/java/com/github/davidmoten/rx2/buffertofile/Options.java
@@ -7,6 +7,7 @@ import java.util.concurrent.Callable;
 
 import org.reactivestreams.Publisher;
 
+import com.github.davidmoten.guavamini.Optional;
 import com.github.davidmoten.guavamini.Preconditions;
 import com.github.davidmoten.guavamini.annotations.VisibleForTesting;
 import com.github.davidmoten.rx2.internal.flowable.buffertofile.FlowableOnBackpressureBufferToFile;
@@ -158,7 +159,7 @@ public final class Options {
 
         private Callable<File> fileFactory = FileFactoryHolder.INSTANCE;
         private int pageSizeBytes = 1024 * 1024;
-        private Scheduler scheduler = Schedulers.io();
+        private Optional<Scheduler> scheduler = Optional.absent();
 
         BuilderObservable() {
         }
@@ -186,7 +187,7 @@ public final class Options {
          * @return this
          */
         public BuilderObservable scheduler(Scheduler scheduler) {
-            this.scheduler = scheduler;
+            this.scheduler = Optional.of(scheduler);
             return this;
         }
 
@@ -237,7 +238,8 @@ public final class Options {
         }
 
         public <T> Function<Observable<T>, Flowable<T>> serializer(final Serializer<T> serializer) {
-            final Options options = new Options(fileFactory, pageSizeBytes, scheduler);
+            Scheduler s = scheduler.isPresent() ? scheduler.get() : Schedulers.io();
+            final Options options = new Options(fileFactory, pageSizeBytes, s);
             return new Function<Observable<T>, Flowable<T>>() {
 
                 @Override


### PR DESCRIPTION
Currently if I specify a scheduler for `RetryWhen`, a default scheduler from `Schedulers` class is still requested by calling `Schedulers.computation()` method.

It is needed to avoid requesting of a default scheduler from `Schedulers` when another scheduler is specified in `RetryWhen` cause it calls `RxJavaPlugins.onComputationHandler` on every request while the requested default scheduler is not actually used.

Same for `buffertofile.Options`, but `Schedulers.io()` is used there.
